### PR TITLE
Implement core domain logic and tests

### DIFF
--- a/classquest/src/core/config.test.ts
+++ b/classquest/src/core/config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from './config';
+
+describe('DEFAULT_SETTINGS', () => {
+  it('provides the initial class configuration', () => {
+    expect(DEFAULT_SETTINGS).toEqual({
+      className: 'Meine Klasse',
+      xpPerLevel: 100,
+      streakThresholdForBadge: 5
+    });
+  });
+});

--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -1,6 +1,7 @@
-export const DEFAULT_SETTINGS = {
+import type { Settings } from '../types/models';
+
+export const DEFAULT_SETTINGS: Settings = {
   className: 'Meine Klasse',
   xpPerLevel: 100,
-  streakThresholdForBadge: 5,
-  allowNegativeXP: false,
-} as const;
+  streakThresholdForBadge: 5
+};

--- a/classquest/src/core/gameLogic.test.ts
+++ b/classquest/src/core/gameLogic.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest';
+import { processAward, type LogicDeps } from './gameLogic';
+import type { AppState, LogEntry, Quest, Settings, Student } from '../types/models';
+
+const fixedDay = '2025-09-16';
+const deps: LogicDeps = {
+  todayKey: () => fixedDay,
+  now: () => 1000,
+  makeId: () => 'log-1'
+};
+
+const computeYesterday = (day: string) => {
+  const [y, m, d] = day.split('-').map(Number);
+  const dt = new Date(y, m - 1, d);
+  dt.setDate(dt.getDate() - 1);
+  return dt.toISOString().slice(0, 10);
+};
+
+const defaultSettings: Settings = {
+  className: 'Klasse 7a',
+  xpPerLevel: 100,
+  streakThresholdForBadge: 5
+};
+
+const makeStudent = (overrides: Partial<Student> = {}): Student => {
+  const { streaks, lastAwardedDay, awardedBadgeIds, ...rest } = overrides;
+  return {
+    id: 'student-1',
+    alias: 'Alice',
+    xp: 0,
+    level: 1,
+    streaks: streaks ?? {},
+    lastAwardedDay: lastAwardedDay ?? {},
+    awardedBadgeIds: awardedBadgeIds ?? [],
+    ...rest
+  };
+};
+
+const makeQuest = (overrides: Partial<Quest> = {}): Quest => ({
+  id: 'quest-1',
+  name: 'Matheübung',
+  xp: 50,
+  type: 'repeatable',
+  active: true,
+  ...overrides
+});
+
+type StateOptions = {
+  student?: Partial<Student>;
+  quest?: Partial<Quest>;
+  log?: LogEntry[];
+  settings?: Partial<Settings>;
+  students?: Student[];
+  quests?: Quest[];
+};
+
+const createState = (options: StateOptions = {}): AppState => ({
+  students: options.students ?? [makeStudent(options.student)],
+  teams: [],
+  quests: options.quests ?? [makeQuest(options.quest)],
+  badges: [],
+  log: options.log ?? [],
+  settings: { ...defaultSettings, ...(options.settings ?? {}) }
+});
+
+describe('processAward', () => {
+  it('awards XP, starts the streak and logs the completion', () => {
+    const existingLog: LogEntry = {
+      id: 'log-0',
+      timestamp: 10,
+      studentId: 'student-1',
+      questId: 'quest-x',
+      questName: 'Vortag',
+      xpAwarded: 15
+    };
+    const state = createState({ log: [existingLog] });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+
+    expect(result).not.toBe(state);
+    expect(state.log).toHaveLength(1);
+    const updatedStudent = result.students[0];
+    expect(updatedStudent.xp).toBe(50);
+    expect(updatedStudent.level).toBe(1);
+    expect(updatedStudent.streaks['quest-1']).toBe(1);
+    expect(updatedStudent.lastAwardedDay['quest-1']).toBe(fixedDay);
+    expect(updatedStudent.awardedBadgeIds).toEqual([]);
+
+    expect(result.log).toHaveLength(2);
+    expect(result.log[0]).toEqual(existingLog);
+    expect(result.log[1]).toEqual({
+      id: 'log-1',
+      timestamp: 1000,
+      studentId: 'student-1',
+      questId: 'quest-1',
+      questName: 'Matheübung',
+      xpAwarded: 50
+    });
+  });
+
+  it('increments the streak when the quest was completed yesterday', () => {
+    const yesterday = computeYesterday(fixedDay);
+    const state = createState({
+      student: {
+        xp: 90,
+        level: 1,
+        streaks: { 'quest-1': 2 },
+        lastAwardedDay: { 'quest-1': yesterday }
+      }
+    });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+    const updatedStudent = result.students[0];
+
+    expect(updatedStudent.streaks['quest-1']).toBe(3);
+    expect(updatedStudent.xp).toBe(140);
+    expect(updatedStudent.level).toBe(2);
+  });
+
+  it('resets the streak when a day was skipped', () => {
+    const yesterday = computeYesterday(fixedDay);
+    const dayBeforeYesterday = computeYesterday(yesterday);
+    const state = createState({
+      student: {
+        streaks: { 'quest-1': 4 },
+        lastAwardedDay: { 'quest-1': dayBeforeYesterday }
+      }
+    });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+
+    expect(result.students[0].streaks['quest-1']).toBe(1);
+  });
+
+  it('keeps the streak unchanged for repeatable quests on the same day', () => {
+    const state = createState({
+      student: {
+        xp: 200,
+        level: 3,
+        streaks: { 'quest-1': 3 },
+        lastAwardedDay: { 'quest-1': fixedDay }
+      }
+    });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+    const updatedStudent = result.students[0];
+
+    expect(updatedStudent.streaks['quest-1']).toBe(3);
+    expect(updatedStudent.xp).toBe(250);
+    expect(updatedStudent.lastAwardedDay['quest-1']).toBe(fixedDay);
+  });
+
+  it('prevents awarding the same daily quest twice on the same day', () => {
+    const state = createState({ quest: { type: 'daily' } });
+
+    const firstAward = processAward(state, 'student-1', 'quest-1', deps);
+    const secondAward = processAward(firstAward, 'student-1', 'quest-1', deps);
+
+    expect(secondAward).toBe(firstAward);
+    expect(firstAward.log).toHaveLength(1);
+    expect(firstAward.students[0].xp).toBe(50);
+  });
+
+  it('prevents awarding a one-off quest more than once', () => {
+    const state = createState({ quest: { type: 'oneoff' } });
+
+    const firstAward = processAward(state, 'student-1', 'quest-1', deps);
+    const secondAward = processAward(firstAward, 'student-1', 'quest-1', deps);
+
+    expect(secondAward).toBe(firstAward);
+    expect(firstAward.students[0].xp).toBe(50);
+    expect(firstAward.log).toHaveLength(1);
+  });
+
+  it('awards the streak badge exactly once at the threshold', () => {
+    const yesterday = computeYesterday(fixedDay);
+    const state = createState({
+      student: {
+        streaks: { 'quest-1': 4 },
+        lastAwardedDay: { 'quest-1': yesterday }
+      }
+    });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+    const updatedStudent = result.students[0];
+
+    expect(updatedStudent.streaks['quest-1']).toBe(5);
+    expect(updatedStudent.awardedBadgeIds).toEqual(['5-day-streak-badge']);
+
+    const alreadyBadged = createState({
+      student: {
+        streaks: { 'quest-1': 4 },
+        lastAwardedDay: { 'quest-1': yesterday },
+        awardedBadgeIds: ['5-day-streak-badge']
+      }
+    });
+
+    const again = processAward(alreadyBadged, 'student-1', 'quest-1', deps);
+    expect(again.students[0].awardedBadgeIds).toEqual(['5-day-streak-badge']);
+  });
+
+  it('ignores inactive quests', () => {
+    const state = createState({ quest: { active: false } });
+
+    const result = processAward(state, 'student-1', 'quest-1', deps);
+
+    expect(result).toBe(state);
+  });
+
+  it('returns the original state when the student is unknown', () => {
+    const state = createState();
+
+    const result = processAward(state, 'unknown', 'quest-1', deps);
+
+    expect(result).toBe(state);
+  });
+
+  it('returns the original state when the quest is unknown', () => {
+    const state = createState();
+
+    const result = processAward(state, 'student-1', 'missing-quest', deps);
+
+    expect(result).toBe(state);
+  });
+});

--- a/classquest/src/core/gameLogic.ts
+++ b/classquest/src/core/gameLogic.ts
@@ -1,0 +1,85 @@
+import type { AppState, ID } from '../types/models';
+import { levelFromXP, todayKey as realTodayKey } from './xp';
+
+export interface LogicDeps {
+  todayKey: () => string;
+  now: () => number;
+  makeId: () => ID;
+}
+
+export const defaultDeps: LogicDeps = {
+  todayKey: () => realTodayKey(),
+  now: () => Date.now(),
+  makeId: () => globalThis.crypto?.randomUUID?.() ?? `id_${Math.random().toString(36).slice(2)}`
+};
+
+const streakBadgeId = (n: number) => `${n}-day-streak-badge`;
+
+export function processAward(
+  state: AppState,
+  studentId: ID,
+  questId: ID,
+  deps: LogicDeps = defaultDeps
+): AppState {
+  const day = deps.todayKey();
+
+  const student = state.students.find(s => s.id === studentId);
+  const quest = state.quests.find(q => q.id === questId);
+  if (!student || !quest || !quest.active) return state;
+
+  if (quest.type === 'daily') {
+    if (student.lastAwardedDay[questId] === day) return state;
+  }
+  if (quest.type === 'oneoff') {
+    if (student.lastAwardedDay[questId]) return state;
+  }
+
+  const prevStreak = student.streaks[questId] ?? 0;
+  const lastDay = student.lastAwardedDay[questId];
+
+  const yesterday = (() => {
+    const [y, m, d] = day.split('-').map(Number);
+    const dt = new Date(y, m - 1, d);
+    dt.setDate(dt.getDate() - 1);
+    return dt.toISOString().slice(0, 10);
+  })();
+
+  let newStreak = 1;
+  if (lastDay === yesterday) newStreak = prevStreak + 1;
+  else if (lastDay === day) newStreak = prevStreak;
+  else newStreak = 1;
+
+  const newXP = student.xp + quest.xp;
+  const newLevel = levelFromXP(newXP, state.settings.xpPerLevel);
+
+  const threshold = state.settings.streakThresholdForBadge;
+  const candidateBadgeId = streakBadgeId(threshold);
+  const alreadyHas = student.awardedBadgeIds.includes(candidateBadgeId);
+  const shouldAwardBadge = newStreak === threshold && !alreadyHas;
+
+  const updatedStudent = {
+    ...student,
+    xp: newXP,
+    level: newLevel,
+    streaks: { ...student.streaks, [questId]: newStreak },
+    lastAwardedDay: { ...student.lastAwardedDay, [questId]: day },
+    awardedBadgeIds: shouldAwardBadge
+      ? [...student.awardedBadgeIds, candidateBadgeId]
+      : student.awardedBadgeIds
+  };
+
+  const newLogEntry = {
+    id: deps.makeId(),
+    timestamp: deps.now(),
+    studentId,
+    questId,
+    questName: quest.name,
+    xpAwarded: quest.xp
+  };
+
+  return {
+    ...state,
+    students: state.students.map(s => (s.id === studentId ? updatedStudent : s)),
+    log: [...state.log, newLogEntry]
+  };
+}

--- a/classquest/src/core/xp.test.ts
+++ b/classquest/src/core/xp.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { levelFromXP, todayKey } from './xp';
+
+describe('levelFromXP', () => {
+  it.each([
+    { xp: 0, expected: 1 },
+    { xp: 99, expected: 1 },
+    { xp: 100, expected: 2 },
+    { xp: 199, expected: 2 },
+    { xp: 200, expected: 3 }
+  ])('computes level $expected for $xp XP when xpPerLevel=100', ({ xp, expected }) => {
+    expect(levelFromXP(xp, 100)).toBe(expected);
+  });
+
+  it('returns level 1 when xpPerLevel is zero or negative', () => {
+    expect(levelFromXP(500, 0)).toBe(1);
+    expect(levelFromXP(500, -10)).toBe(1);
+  });
+
+  it('treats negative XP as zero for level calculation', () => {
+    expect(levelFromXP(-50, 100)).toBe(1);
+  });
+});
+
+describe('todayKey', () => {
+  it('formats the provided date as YYYY-MM-DD in local time', () => {
+    const date = new Date(2025, 11, 24, 10, 30, 0);
+    expect(todayKey(date)).toBe('2025-12-24');
+  });
+
+  it('pads month and day with leading zeros', () => {
+    const date = new Date(2025, 0, 5, 8, 15, 0);
+    expect(todayKey(date)).toBe('2025-01-05');
+  });
+});

--- a/classquest/src/core/xp.ts
+++ b/classquest/src/core/xp.ts
@@ -1,0 +1,11 @@
+export function levelFromXP(xp: number, xpPerLevel: number): number {
+  if (xpPerLevel <= 0) return 1;
+  return Math.floor(Math.max(0, xp) / xpPerLevel) + 1;
+}
+
+export function todayKey(date = new Date()): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,65 +1,56 @@
 export type ID = string;
 
-export type Badge = {
-  id: ID;
-  name: string;
-  icon?: string;
-  description?: string;
-};
-
-export type Student = {
+export interface Student {
   id: ID;
   alias: string;
   xp: number;
   level: number;
-  streaks: Record<ID, number>;
-  lastAwardedDay: Record<ID, string>;
-  badges: Badge[];
   teamId?: ID;
-};
+  streaks: { [questId: ID]: number };
+  lastAwardedDay: { [questId: ID]: string };
+  awardedBadgeIds: ID[];
+}
 
-export type Team = {
+export interface Team {
   id: ID;
   name: string;
-  memberIds: ID[];
-};
+}
 
-export type QuestType = 'daily' | 'repeatable' | 'oneoff';
-export type QuestTarget = 'individual' | 'team';
-
-export type Quest = {
+export interface Quest {
   id: ID;
   name: string;
-  description?: string;
   xp: number;
-  type: QuestType;
-  target: QuestTarget;
-  isPersonalTo?: ID;
+  type: 'daily' | 'repeatable' | 'oneoff';
   active: boolean;
-};
+}
 
-export type LogEntry = {
+export interface Badge {
+  id: ID;
+  name: string;
+  description: string;
+  imageFile: string;
+}
+
+export interface LogEntry {
   id: ID;
   timestamp: number;
   studentId: ID;
   questId: ID;
   questName: string;
-  xp: number;
-  note?: string;
-};
+  xpAwarded: number;
+}
 
-export type Settings = {
+export interface Settings {
   className: string;
   xpPerLevel: number;
   streakThresholdForBadge: number;
-  allowNegativeXP?: boolean;
-};
+}
 
-export type AppState = {
+export interface AppState {
   students: Student[];
   teams: Team[];
   quests: Quest[];
-  logs: LogEntry[];
+  badges: Badge[];
+  log: LogEntry[];
   settings: Settings;
-  version: number;
-};
+}


### PR DESCRIPTION
## Summary
- align the domain model types with the refined student, quest, badge, and app state structures
- add pure XP utilities and deterministic quest award processing with injectable dependencies
- cover the core logic and default settings with Vitest suites to ensure streak, badge, and logging rules

## Testing
- npm run test
- npm run test -- --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9baa67978832c88735daecc83bbda