### PR TITLE
Implement core domain logic and tests

### DIFF
--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -1,0 +1,6 @@
+export const DEFAULT_SETTINGS = {
+  className: 'Meine Klasse',
+  xpPerLevel: 100,
+  streakThresholdForBadge: 5,
+  allowNegativeXP: false,
+} as const;

--- a/classquest/src/core/gameLogic.ts
+++ b/classquest/src/core/gameLogic.ts
@@ -1,0 +1,115 @@
+import { todayKey, levelFromXP } from './xp';
+import type { Student, Quest, LogEntry, AppState, ID } from '~/types/models';
+
+const awardStreak = (
+  student: Student,
+  questId: ID,
+  questName: string,
+  dateKey: string,
+  streakThresholdForBadge: number,
+) => {
+  const streaks = { ...student.streaks };
+  const lastDays = { ...student.lastAwardedDay };
+  const previousDay = new Date();
+  previousDay.setDate(previousDay.getDate() - 1);
+  const yesterdayKey = todayKey(previousDay);
+
+  const lastKey = lastDays[questId];
+  const isConsecutive = lastKey === yesterdayKey;
+  const nextStreak = isConsecutive ? (streaks[questId] ?? 0) + 1 : 1;
+
+  streaks[questId] = nextStreak;
+  lastDays[questId] = dateKey;
+
+  const hasBadge = student.badges.some((b) => b.id === `streak-${questId}`);
+  const badges = hasBadge || nextStreak < streakThresholdForBadge
+    ? student.badges.slice()
+    : student.badges.concat({
+        id: `streak-${questId}`,
+        name: `${questName} ${streakThresholdForBadge}er Streak`,
+      });
+
+  return { streaks, lastDays, badges };
+};
+
+const buildLogEntry = (
+  log: LogEntry,
+  quest: Quest,
+  studentId: ID,
+  note?: string,
+): LogEntry => ({
+  ...log,
+  questId: quest.id,
+  questName: quest.name,
+  studentId,
+  note,
+});
+
+export function processAward(state: AppState, studentId: ID, quest: Quest, note?: string): AppState {
+  const student = state.students.find((s) => s.id === studentId);
+  if (!student) return state;
+
+  const dateKey = todayKey();
+  if (quest.type === 'daily' && student.lastAwardedDay[quest.id] === dateKey) {
+    return state;
+  }
+  if (quest.type === 'oneoff' && (student.streaks[quest.id] ?? 0) > 0) {
+    return state;
+  }
+
+  const xpGain = quest.xp;
+  const updatedXP = state.settings.allowNegativeXP
+    ? student.xp + xpGain
+    : Math.max(0, student.xp + xpGain);
+  const level = Math.max(1, levelFromXP(updatedXP, state.settings.xpPerLevel));
+
+  let streaks = student.streaks;
+  let lastAwardedDay = student.lastAwardedDay;
+  let badges = student.badges;
+
+  if (quest.type === 'daily') {
+    const update = awardStreak(
+      student,
+      quest.id,
+      quest.name,
+      dateKey,
+      state.settings.streakThresholdForBadge,
+    );
+    streaks = update.streaks;
+    lastAwardedDay = update.lastDays;
+    badges = update.badges;
+  } else {
+    streaks = { ...streaks, [quest.id]: (streaks[quest.id] ?? 0) + 1 };
+    lastAwardedDay = { ...lastAwardedDay, [quest.id]: dateKey };
+  }
+
+  const updatedStudent: Student = {
+    ...student,
+    xp: updatedXP,
+    level,
+    streaks,
+    lastAwardedDay,
+    badges,
+  };
+
+  const timestamp = Date.now();
+  const log: LogEntry = buildLogEntry(
+    {
+      id: `${timestamp}-${Math.random()}`,
+      timestamp,
+      studentId,
+      questId: quest.id,
+      questName: quest.name,
+      xp: quest.xp,
+    },
+    quest,
+    studentId,
+    note,
+  );
+
+  return {
+    ...state,
+    students: state.students.map((s) => (s.id === studentId ? updatedStudent : s)),
+    logs: [...state.logs, log],
+  };
+}

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -1,0 +1,233 @@
+import { DEFAULT_SETTINGS } from './config';
+import { processAward } from './gameLogic';
+import { levelFromXP } from './xp';
+import type {
+  AppState,
+  ID,
+  Quest,
+  QuestTarget,
+  Settings,
+  Student,
+  Team,
+} from '~/types/models';
+
+const sanitizeXP = (xp: number | undefined, allowNegative = false) => {
+  if (typeof xp !== 'number' || Number.isNaN(xp)) return 0;
+  return allowNegative ? xp : Math.max(0, xp);
+};
+
+const unique = <T>(values: T[]) => Array.from(new Set(values));
+
+const updateTeamMembership = (teams: Team[], teamId: ID | undefined, studentId: ID) =>
+  teams.map((team) => {
+    const members = new Set(team.memberIds);
+    members.delete(studentId);
+
+    if (teamId && team.id === teamId) {
+      members.add(studentId);
+    }
+
+    return {
+      ...team,
+      memberIds: Array.from(members),
+    } satisfies Team;
+  });
+
+const detachMembersFromTeams = (teams: Team[], memberIds: ID[]) =>
+  teams.map((team) => ({
+    ...team,
+    memberIds: team.memberIds.filter((memberId) => !memberIds.includes(memberId)),
+  }));
+
+const mapStudentsWithTeams = (students: Student[], teamId: ID, memberIds: ID[]) =>
+  students.map((student) =>
+    memberIds.includes(student.id)
+      ? { ...student, teamId }
+      : student.teamId === teamId && !memberIds.includes(student.id)
+        ? { ...student, teamId: undefined }
+        : student,
+  );
+
+const buildTeam = (team: Team, existingStudents: Student[]) => {
+  const knownMemberIds = team.memberIds.filter((memberId) =>
+    existingStudents.some((student) => student.id === memberId),
+  );
+
+  return {
+    ...team,
+    memberIds: unique(knownMemberIds),
+  } satisfies Team;
+};
+
+export const createInitialState = (
+  settings?: Partial<Settings>,
+  version = 1,
+): AppState => ({
+  students: [],
+  teams: [],
+  quests: [],
+  logs: [],
+  settings: { ...DEFAULT_SETTINGS, ...settings },
+  version,
+});
+
+type StudentInput = {
+  id: ID;
+  alias: string;
+  xp?: number;
+  teamId?: ID;
+};
+
+export const addStudent = (state: AppState, input: StudentInput): AppState => {
+  if (state.students.some((student) => student.id === input.id)) {
+    return state;
+  }
+
+  const sanitizedXP = sanitizeXP(input.xp, state.settings.allowNegativeXP);
+  const targetTeam = input.teamId ? state.teams.find((team) => team.id === input.teamId) : undefined;
+
+  const student: Student = {
+    id: input.id,
+    alias: input.alias,
+    xp: sanitizedXP,
+    level: Math.max(1, levelFromXP(sanitizedXP, state.settings.xpPerLevel)),
+    streaks: {},
+    lastAwardedDay: {},
+    badges: [],
+    teamId: targetTeam?.id,
+  };
+
+  const teams = targetTeam
+    ? updateTeamMembership(state.teams, targetTeam.id, student.id)
+    : state.teams;
+
+  return {
+    ...state,
+    students: [...state.students, student],
+    teams,
+  };
+};
+
+type TeamInput = {
+  id: ID;
+  name: string;
+  memberIds?: ID[];
+};
+
+export const addTeam = (state: AppState, input: TeamInput): AppState => {
+  if (state.teams.some((team) => team.id === input.id)) {
+    return state;
+  }
+
+  const memberIds = unique(input.memberIds ?? []);
+  const team: Team = buildTeam({ id: input.id, name: input.name, memberIds }, state.students);
+
+  const students = team.memberIds.length
+    ? mapStudentsWithTeams(state.students, team.id, team.memberIds)
+    : state.students;
+
+  const teams = team.memberIds.length
+    ? detachMembersFromTeams(state.teams, team.memberIds)
+    : state.teams;
+
+  return {
+    ...state,
+    teams: [...teams, team],
+    students,
+  };
+};
+
+export const assignStudentToTeam = (
+  state: AppState,
+  studentId: ID,
+  teamId: ID | undefined,
+): AppState => {
+  const studentExists = state.students.some((student) => student.id === studentId);
+  if (!studentExists) return state;
+
+  const team = teamId ? state.teams.find((t) => t.id === teamId) : undefined;
+
+  const students = state.students.map((student) =>
+    student.id === studentId ? { ...student, teamId: team?.id } : student,
+  );
+  const teams = updateTeamMembership(state.teams, team?.id, studentId);
+
+  return {
+    ...state,
+    students,
+    teams,
+  };
+};
+
+type QuestInput = Omit<Quest, 'active' | 'target'> & {
+  target?: QuestTarget;
+  active?: boolean;
+};
+
+export const addQuest = (state: AppState, input: QuestInput): AppState => {
+  if (state.quests.some((quest) => quest.id === input.id)) {
+    return state;
+  }
+
+  const quest: Quest = {
+    ...input,
+    active: input.active ?? true,
+    target: input.target ?? 'individual',
+  };
+
+  return {
+    ...state,
+    quests: [...state.quests, quest],
+  };
+};
+
+export const setQuestActive = (state: AppState, questId: ID, active: boolean): AppState => ({
+  ...state,
+  quests: state.quests.map((quest) =>
+    quest.id === questId
+      ? {
+          ...quest,
+          active,
+        }
+      : quest,
+  ),
+});
+
+type AwardParams = {
+  questId: ID;
+  studentId?: ID;
+  teamId?: ID;
+  note?: string;
+};
+
+export const awardQuest = (state: AppState, { questId, studentId, teamId, note }: AwardParams): AppState => {
+  const quest = state.quests.find((q) => q.id === questId);
+  if (!quest || !quest.active) {
+    return state;
+  }
+
+  if (quest.target === 'individual') {
+    const targetStudent = studentId ?? quest.isPersonalTo;
+    if (!targetStudent) return state;
+    if (quest.isPersonalTo && quest.isPersonalTo !== targetStudent) {
+      return state;
+    }
+    return processAward(state, targetStudent, quest, note);
+  }
+
+  const resolvedTeamId = teamId
+    ?? (studentId
+      ? state.students.find((student) => student.id === studentId)?.teamId
+      : undefined);
+  if (!resolvedTeamId) return state;
+
+  const team = state.teams.find((t) => t.id === resolvedTeamId);
+  if (!team) return state;
+
+  return team.memberIds.reduce((nextState, memberId) => {
+    if (quest.isPersonalTo && quest.isPersonalTo !== memberId) {
+      return nextState;
+    }
+    return processAward(nextState, memberId, quest, note);
+  }, state);
+};

--- a/classquest/src/core/xp.ts
+++ b/classquest/src/core/xp.ts
@@ -1,0 +1,8 @@
+export const levelFromXP = (xp: number, xpPerLevel: number) => Math.floor(xp / xpPerLevel) + 1;
+
+export const todayKey = (d = new Date()) => {
+  const y = d.getFullYear();
+  const m = `${d.getMonth()+1}`.padStart(2,'0');
+  const dd = `${d.getDate()}`.padStart(2,'0');
+  return `${y}-${m}-${dd}`;
+};

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,0 +1,31 @@
+export type ID = string;
+export type Badge = { id: ID; name: string; icon?: string; description?: string };
+
+export type Student = {
+  id: ID; alias: string; xp: number; level: number;
+  streaks: Record<ID, number>;
+  lastAwardedDay: Record<ID, string>; // YYYY-MM-DD
+  badges: Badge[]; teamId?: ID;
+};
+
+export type Team = { id: ID; name: string; memberIds: ID[] };
+export type QuestType = 'daily'|'repeatable'|'oneoff';
+export type QuestTarget = 'individual'|'team';
+
+export type Quest = {
+  id: ID; name: string; description?: string; xp: number;
+  type: QuestType; target: QuestTarget; isPersonalTo?: ID; active: boolean;
+};
+
+export type LogEntry = {
+  id: ID; timestamp: number; studentId: ID; questId: ID; questName: string; xp: number; note?: string;
+};
+
+export type Settings = {
+  className: string; xpPerLevel: number; streakThresholdForBadge: number; allowNegativeXP?: boolean;
+};
+
+export type AppState = {
+  students: Student[]; teams: Team[]; quests: Quest[]; logs: LogEntry[];
+  settings: Settings; version: number;
+};

--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { processAward } from '~/core/gameLogic';
+import type { AppState, Quest, Student } from '~/types/models';
+
+const createStudent = (overrides: Partial<Student> = {}): Student => ({
+  id: 'student-1',
+  alias: 'Testy',
+  xp: 0,
+  level: 1,
+  streaks: {},
+  lastAwardedDay: {},
+  badges: [],
+  ...overrides,
+});
+
+const createState = (studentOverrides: Partial<Student> = {}): AppState => ({
+  students: [createStudent(studentOverrides)],
+  teams: [],
+  quests: [],
+  logs: [],
+  settings: {
+    className: 'Demo',
+    xpPerLevel: 100,
+    streakThresholdForBadge: 2,
+    allowNegativeXP: false,
+  },
+  version: 1,
+});
+
+const createQuest = (overrides: Partial<Quest> = {}): Quest => ({
+  id: 'quest-1',
+  name: 'Quest',
+  xp: 50,
+  description: 'Test quest',
+  type: 'repeatable',
+  target: 'individual',
+  active: true,
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('processAward', () => {
+  it('updates xp, level and logs for repeatable quests', () => {
+    const quest = createQuest();
+    const state = createState();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 9));
+    vi.spyOn(Math, 'random').mockReturnValue(0.42);
+
+    const updated = processAward(state, 'student-1', quest, 'Keep going');
+
+    expect(updated.students[0]).toMatchObject({
+      xp: 50,
+      level: 1,
+      streaks: { 'quest-1': 1 },
+      lastAwardedDay: { 'quest-1': '2024-01-01' },
+    });
+    expect(updated.logs).toHaveLength(1);
+    expect(updated.logs[0]).toMatchObject({
+      studentId: 'student-1',
+      questId: 'quest-1',
+      xp: 50,
+      note: 'Keep going',
+      timestamp: new Date(2024, 0, 1, 9).getTime(),
+    });
+    expect(updated.logs[0].id).toBe(`${new Date(2024, 0, 1, 9).getTime()}-0.42`);
+  });
+
+  it('prevents xp from dropping below zero when negatives are disallowed', () => {
+    const quest = createQuest({ xp: -100 });
+    const state = createState({ xp: 40 });
+
+    const updated = processAward(state, 'student-1', quest);
+
+    expect(updated.students[0].xp).toBe(0);
+    expect(updated.students[0].level).toBe(1);
+  });
+
+  it('allows negative xp when configured', () => {
+    const quest = createQuest({ xp: -60 });
+    const state = {
+      ...createState({ xp: 10 }),
+      settings: {
+        className: 'Demo',
+        xpPerLevel: 100,
+        streakThresholdForBadge: 2,
+        allowNegativeXP: true,
+      },
+    } satisfies AppState;
+
+    const updated = processAward(state, 'student-1', quest);
+
+    expect(updated.students[0].xp).toBe(-50);
+  });
+
+  it('ignores repeat awards for daily quests on the same day', () => {
+    const quest = createQuest({ type: 'daily' });
+    const state = createState();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 9));
+
+    const once = processAward(state, 'student-1', quest);
+    const twice = processAward(once, 'student-1', quest);
+
+    expect(twice).toBe(once);
+    expect(twice.logs).toHaveLength(1);
+  });
+
+  it('tracks streaks across consecutive days and awards badges', () => {
+    const quest = createQuest({ type: 'daily', name: 'Mathe' });
+    const state = createState();
+
+    vi.useFakeTimers();
+
+    vi.setSystemTime(new Date(2024, 0, 1, 9));
+    const first = processAward(state, 'student-1', quest);
+    expect(first.students[0].streaks['quest-1']).toBe(1);
+
+    vi.setSystemTime(new Date(2024, 0, 2, 9));
+    const second = processAward(first, 'student-1', quest);
+    expect(second.students[0].streaks['quest-1']).toBe(2);
+    expect(second.students[0].badges).toHaveLength(1);
+    expect(second.students[0].badges[0]).toMatchObject({
+      id: 'streak-quest-1',
+      name: 'Mathe 2er Streak',
+    });
+
+    vi.setSystemTime(new Date(2024, 0, 4, 9));
+    const reset = processAward(second, 'student-1', quest);
+    expect(reset.students[0].streaks['quest-1']).toBe(1);
+  });
+
+  it('prevents one-off quests from being repeated', () => {
+    const quest = createQuest({ type: 'oneoff' });
+    const state = createState();
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 9));
+
+    const first = processAward(state, 'student-1', quest);
+    const second = processAward(first, 'student-1', quest);
+
+    expect(second).toBe(first);
+    expect(first.logs).toHaveLength(1);
+  });
+
+  it('returns original state when the student does not exist', () => {
+    const quest = createQuest();
+    const state = createState();
+
+    const result = processAward(state, 'missing', quest);
+    expect(result).toBe(state);
+  });
+});

--- a/classquest/tests/state.test.ts
+++ b/classquest/tests/state.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  addQuest,
+  addStudent,
+  addTeam,
+  assignStudentToTeam,
+  awardQuest,
+  createInitialState,
+  setQuestActive,
+} from '~/core/state';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('state helpers', () => {
+  it('creates an initial state with default settings', () => {
+    const state = createInitialState({ xpPerLevel: 250 }, 3);
+    expect(state.settings.className).toBe('Meine Klasse');
+    expect(state.settings.xpPerLevel).toBe(250);
+    expect(state.version).toBe(3);
+  });
+
+  it('adds students with sanitized xp and computed level', () => {
+    const state = createInitialState();
+    const withStudent = addStudent(state, { id: 's1', alias: 'Alice', xp: -50 });
+    expect(withStudent.students).toHaveLength(1);
+    expect(withStudent.students[0]).toMatchObject({
+      xp: 0,
+      level: 1,
+      teamId: undefined,
+    });
+  });
+
+  it('respects allowNegativeXP when adding students', () => {
+    const state = createInitialState({ allowNegativeXP: true });
+    const withStudent = addStudent(state, { id: 's1', alias: 'Alice', xp: -25 });
+    expect(withStudent.students[0].xp).toBe(-25);
+  });
+
+  it('ignores duplicate students', () => {
+    const state = createInitialState();
+    const once = addStudent(state, { id: 's1', alias: 'Alice' });
+    const twice = addStudent(once, { id: 's1', alias: 'Bob' });
+    expect(twice.students).toHaveLength(1);
+    expect(twice.students[0].alias).toBe('Alice');
+  });
+
+  it('assigns new students to existing teams', () => {
+    const base = addTeam(createInitialState(), { id: 't1', name: 'Rockets' });
+    const state = addStudent(base, { id: 's1', alias: 'Alice', teamId: 't1' });
+    expect(state.students[0].teamId).toBe('t1');
+    expect(state.teams[0].memberIds).toContain('s1');
+  });
+
+  it('ignores unknown teams when adding students', () => {
+    const state = addStudent(createInitialState(), { id: 's1', alias: 'Alice', teamId: 'missing' });
+    expect(state.students[0].teamId).toBeUndefined();
+  });
+
+  it('adds teams and attaches known members', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addStudent(state, { id: 's2', alias: 'Bob' });
+    state = addTeam(state, { id: 't1', name: 'Rockets', memberIds: ['s1', 's2', 's1', 'missing'] });
+
+    expect(state.teams[0]).toMatchObject({ id: 't1', memberIds: ['s1', 's2'] });
+    expect(state.students.map((s) => s.teamId)).toEqual(['t1', 't1']);
+  });
+
+  it('moves members to the latest team when overlapping', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addTeam(state, { id: 't1', name: 'Team One', memberIds: ['s1'] });
+    state = addTeam(state, { id: 't2', name: 'Team Two', memberIds: ['s1'] });
+
+    const oldTeam = state.teams.find((team) => team.id === 't1');
+    const newTeam = state.teams.find((team) => team.id === 't2');
+
+    expect(oldTeam?.memberIds).toHaveLength(0);
+    expect(newTeam?.memberIds).toEqual(['s1']);
+    expect(state.students[0].teamId).toBe('t2');
+  });
+
+  it('assigns and removes students from teams', () => {
+    let state = createInitialState();
+    state = addTeam(state, { id: 't1', name: 'One' });
+    state = addTeam(state, { id: 't2', name: 'Two' });
+    state = addStudent(state, { id: 's1', alias: 'Alice', teamId: 't1' });
+
+    state = assignStudentToTeam(state, 's1', 't2');
+    expect(state.students[0].teamId).toBe('t2');
+    expect(state.teams.find((team) => team.id === 't1')?.memberIds).toHaveLength(0);
+    expect(state.teams.find((team) => team.id === 't2')?.memberIds).toContain('s1');
+
+    state = assignStudentToTeam(state, 's1', undefined);
+    expect(state.students[0].teamId).toBeUndefined();
+    expect(state.teams.every((team) => team.memberIds.length === 0)).toBe(true);
+  });
+
+  it('adds quests with defaults and toggles activity', () => {
+    let state = createInitialState();
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 100,
+      description: 'Desc',
+      type: 'daily',
+      target: 'team',
+      isPersonalTo: undefined,
+      active: false,
+    });
+
+    expect(state.quests[0]).toMatchObject({
+      target: 'team',
+      active: false,
+    });
+
+    state = addQuest(state, {
+      id: 'q2',
+      name: 'Quest 2',
+      xp: 25,
+      description: 'Desc',
+      type: 'repeatable',
+      isPersonalTo: undefined,
+    });
+
+    expect(state.quests[1]).toMatchObject({ target: 'individual', active: true });
+
+    state = setQuestActive(state, 'q2', false);
+    expect(state.quests[1].active).toBe(false);
+  });
+
+  it('awards individual quests to specified students', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      description: 'Desc',
+      xp: 40,
+      type: 'repeatable',
+      target: 'individual',
+      active: true,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 12));
+    vi.spyOn(Math, 'random').mockReturnValue(0.1);
+
+    const awarded = awardQuest(state, { questId: 'q1', studentId: 's1', note: 'Great job' });
+    expect(awarded.students[0].xp).toBe(40);
+    expect(awarded.logs).toHaveLength(1);
+    expect(awarded.logs[0].note).toBe('Great job');
+  });
+
+  it('derives personal quest target when none is specified', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 10,
+      type: 'repeatable',
+      target: 'individual',
+      active: true,
+      isPersonalTo: 's1',
+    });
+
+    const awarded = awardQuest(state, { questId: 'q1' });
+    expect(awarded.students[0].xp).toBe(10);
+  });
+
+  it('blocks personal quests for other students', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addStudent(state, { id: 's2', alias: 'Bob' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 10,
+      type: 'repeatable',
+      target: 'individual',
+      active: true,
+      isPersonalTo: 's1',
+    });
+
+    const denied = awardQuest(state, { questId: 'q1', studentId: 's2' });
+    expect(denied.logs).toHaveLength(0);
+    expect(denied.students[1].xp).toBe(0);
+  });
+
+  it('awards team quests to all members', () => {
+    let state = createInitialState();
+    state = addTeam(state, { id: 't1', name: 'Team', memberIds: [] });
+    state = addStudent(state, { id: 's1', alias: 'Alice', teamId: 't1' });
+    state = addStudent(state, { id: 's2', alias: 'Bob', teamId: 't1' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Team Quest',
+      xp: 15,
+      type: 'repeatable',
+      target: 'team',
+      active: true,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 12));
+
+    const awarded = awardQuest(state, { questId: 'q1', teamId: 't1' });
+    expect(awarded.students.map((s) => s.xp)).toEqual([15, 15]);
+    expect(awarded.logs).toHaveLength(2);
+  });
+
+  it('derives team from student when awarding team quests', () => {
+    let state = createInitialState();
+    state = addTeam(state, { id: 't1', name: 'Team', memberIds: [] });
+    state = addStudent(state, { id: 's1', alias: 'Alice', teamId: 't1' });
+    state = addStudent(state, { id: 's2', alias: 'Bob', teamId: 't1' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Team Quest',
+      xp: 20,
+      type: 'repeatable',
+      target: 'team',
+      active: true,
+    });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 0, 1, 12));
+
+    const awarded = awardQuest(state, { questId: 'q1', studentId: 's1' });
+    expect(awarded.students.map((s) => s.xp)).toEqual([20, 20]);
+  });
+
+  it('respects personal recipients when awarding team quests', () => {
+    let state = createInitialState();
+    state = addTeam(state, { id: 't1', name: 'Team', memberIds: [] });
+    state = addStudent(state, { id: 's1', alias: 'Alice', teamId: 't1' });
+    state = addStudent(state, { id: 's2', alias: 'Bob', teamId: 't1' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Team Quest',
+      xp: 20,
+      type: 'repeatable',
+      target: 'team',
+      active: true,
+      isPersonalTo: 's2',
+    });
+
+    const awarded = awardQuest(state, { questId: 'q1', teamId: 't1' });
+    expect(awarded.students.map((s) => s.xp)).toEqual([0, 20]);
+  });
+
+  it('ignores inactive quests during awarding', () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice' });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 20,
+      type: 'repeatable',
+      target: 'individual',
+      active: false,
+    });
+
+    const awarded = awardQuest(state, { questId: 'q1', studentId: 's1' });
+    expect(awarded).toBe(state);
+  });
+});

--- a/classquest/tests/xp.test.ts
+++ b/classquest/tests/xp.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import { levelFromXP, todayKey } from '~/core/xp';
+
+describe('xp helpers', () => {
+  it('calculates level based on xp per level', () => {
+    expect(levelFromXP(0, 100)).toBe(1);
+    expect(levelFromXP(99, 100)).toBe(1);
+    expect(levelFromXP(100, 100)).toBe(2);
+    expect(levelFromXP(250, 100)).toBe(3);
+  });
+
+  it('formats today key for provided date', () => {
+    const key = todayKey(new Date(2024, 0, 5));
+    expect(key).toBe('2024-01-05');
+  });
+
+  it('uses current date when none provided', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2024, 6, 15, 10, 30, 0));
+
+    expect(todayKey()).toBe('2024-07-15');
+
+    vi.useRealTimers();
+  });
+});

--- a/classquest/tsconfig.json
+++ b/classquest/tsconfig.json
@@ -24,6 +24,6 @@
       "~/*": ["src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## Summary
- define the core domain types and default configuration
- add XP utilities plus award logic for streaks, badges, and logs
- implement pure state helpers with comprehensive Vitest coverage

## Testing
- npm run test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cacc517710832ca2439a24d9cda67e