### PR TITLE
Add local storage adapter tests and implementation

### DIFF
--- a/classquest/src/services/storage/localStorage.ts
+++ b/classquest/src/services/storage/localStorage.ts
@@ -1,0 +1,50 @@
+import type { AppState } from '~/types/models';
+
+export const STORAGE_KEY = 'classquest:state';
+
+const getStorage = (): Storage => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+
+  const storage = (globalThis as { localStorage?: Storage }).localStorage;
+  if (storage) return storage;
+
+  throw new Error('localStorage is not available');
+};
+
+const parseState = (json: string): AppState => {
+  const parsed = JSON.parse(json) as AppState | null;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('Invalid state payload');
+  }
+  return parsed;
+};
+
+export class LocalStorageAdapter {
+  async saveState(state: AppState): Promise<void> {
+    const payload = JSON.stringify(state);
+    getStorage().setItem(STORAGE_KEY, payload);
+  }
+
+  async loadState(): Promise<AppState | null> {
+    const storage = getStorage();
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    try {
+      return parseState(raw);
+    } catch (error) {
+      console.warn('Failed to parse stored state', error);
+      return null;
+    }
+  }
+
+  async exportState(state: AppState): Promise<string> {
+    return JSON.stringify(state);
+  }
+
+  async importState(json: string): Promise<AppState> {
+    return parseState(json);
+  }
+}

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LocalStorageAdapter, STORAGE_KEY } from '~/services/storage/localStorage';
+import type { AppState } from '~/types/models';
+
+type GlobalWithStorage = typeof globalThis & { localStorage?: Storage };
+
+const ensureLocalStorage = (): Storage => {
+  const globalScope = globalThis as GlobalWithStorage;
+  if (!globalScope.localStorage) {
+    const store = new Map<string, string>();
+    const mockStorage: Storage = {
+      get length() {
+        return store.size;
+      },
+      clear: () => {
+        store.clear();
+      },
+      getItem: (key) => store.get(key) ?? null,
+      key: (index) => Array.from(store.keys())[index] ?? null,
+      removeItem: (key) => {
+        store.delete(key);
+      },
+      setItem: (key, value) => {
+        store.set(key, value);
+      },
+    };
+
+    globalScope.localStorage = mockStorage;
+  }
+
+  return globalScope.localStorage;
+};
+
+const sampleState = (): AppState => ({
+  students: [{ id: 's1', alias: 'Lena', xp: 10, level: 1, streaks: {}, lastAwardedDay: {}, badges: [] }],
+  teams: [],
+  quests: [{ id: 'q1', name: 'Hausaufgaben', xp: 10, type: 'daily', target: 'individual', active: true }],
+  logs: [],
+  settings: { className: '4a', xpPerLevel: 100, streakThresholdForBadge: 5, allowNegativeXP: false },
+  version: 1,
+});
+
+describe('LocalStorageAdapter', () => {
+  let adapter: LocalStorageAdapter;
+  let storage: Storage;
+
+  beforeEach(() => {
+    adapter = new LocalStorageAdapter();
+    storage = ensureLocalStorage();
+    storage.clear();
+  });
+
+  it('export -> import roundtrip yields deep-equal state', async () => {
+    const s = sampleState();
+    const json = await adapter.exportState(s);
+    const restored = await adapter.importState(json);
+    expect(restored).toEqual(s);
+  });
+
+  it('saveState -> loadState roundtrip via localStorage', async () => {
+    const s = sampleState();
+    await adapter.saveState(s);
+    const loaded = await adapter.loadState();
+    expect(loaded).toEqual(s);
+  });
+
+  it('loadState returns null on corrupt JSON', async () => {
+    storage.setItem(STORAGE_KEY, '{bad json');
+    const loaded = await adapter.loadState();
+    expect(loaded).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a local storage adapter for persisting `AppState` with safe fallbacks when `localStorage` is unavailable
- cover the adapter with Vitest tests, including a polyfilled storage for non-DOM environments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cad91fd408832caa3dbf487d244779