### PR TITLE
feat: add global app context and demo UI

### DIFF
--- a/classquest/src/App.tsx
+++ b/classquest/src/App.tsx
@@ -1,31 +1,165 @@
-import { useState } from 'react';
-import reactLogo from './assets/react.svg';
-import viteLogo from '/vite.svg';
-import './App.css';
+import { useMemo, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import type { ID, Quest } from '~/types/models';
 
-function App() {
-  const [count, setCount] = useState(0);
+type SimpleQuestType = 'daily' | 'repeatable' | 'oneoff';
 
-  return (
-    <>
-      <div>
-        <a href="https://vitejs.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>count is {count}</button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">Click on the Vite and React logos to learn more</p>
-    </>
-  );
+function newQuest(name: string, xp: number, type: SimpleQuestType = 'daily'): Quest {
+  const trimmed = name.trim();
+  const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  return { id, name: trimmed || 'Neue Quest', xp, type, target: 'individual', active: true };
 }
 
-export default App;
+export default function App() {
+  const { state, dispatch } = useApp();
+  const [alias, setAlias] = useState('');
+  const [qName, setQName] = useState('Hausaufgaben');
+  const [qXP, setQXP] = useState(10);
+  const [qType, setQType] = useState<SimpleQuestType>('daily');
+
+  const activeQuests = useMemo(() => state.quests.filter((q) => q.active), [state.quests]);
+  const studentAliasById = useMemo(
+    () =>
+      Object.fromEntries(state.students.map((student) => [student.id, student.alias])) as Record<
+        ID,
+        string
+      >,
+    [state.students],
+  );
+
+  const handleAddQuest = () => {
+    const trimmed = qName.trim();
+    if (!trimmed) return;
+    dispatch({ type: 'ADD_QUEST', quest: newQuest(trimmed, qXP, qType) });
+    setQName('');
+  };
+
+  return (
+    <div style={{ maxWidth: 960, margin: '0 auto', padding: 16 }}>
+      <h1 style={{ marginBottom: 8 }}>{state.settings.className || 'ClassQuest'}</h1>
+
+      {/* Students */}
+      <section style={{ padding: 12, background: '#fff', borderRadius: 12, marginBottom: 16 }}>
+        <h2>Students</h2>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+          <input
+            aria-label="Alias"
+            placeholder="Alias"
+            value={alias}
+            onChange={(event) => setAlias(event.target.value)}
+          />
+          <button
+            onClick={() => {
+              if (alias.trim()) {
+                dispatch({ type: 'ADD_STUDENT', alias: alias.trim() });
+                setAlias('');
+              }
+            }}
+          >
+            Add
+          </button>
+        </div>
+        <ul>
+          {state.students.map((student) => (
+            <li key={student.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <strong>{student.alias}</strong> — {student.xp} XP (Lvl {student.level})
+              <button onClick={() => dispatch({ type: 'REMOVE_STUDENT', id: student.id })}>
+                Remove
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Quests */}
+      <section style={{ padding: 12, background: '#fff', borderRadius: 12, marginBottom: 16 }}>
+        <h2>Quests</h2>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 8 }}>
+          <input
+            aria-label="Quest name"
+            placeholder="Quest name"
+            value={qName}
+            onChange={(event) => setQName(event.target.value)}
+          />
+          <input
+            aria-label="XP"
+            type="number"
+            min={0}
+            value={qXP}
+            onChange={(event) => setQXP(Number.parseInt(event.target.value || '0', 10))}
+          />
+          <select
+            aria-label="Type"
+            value={qType}
+            onChange={(event) => setQType(event.target.value as SimpleQuestType)}
+          >
+            <option value="daily">daily</option>
+            <option value="repeatable">repeatable</option>
+            <option value="oneoff">oneoff</option>
+          </select>
+          <button onClick={handleAddQuest}>Add quest</button>
+        </div>
+        <ul>
+          {state.quests.map((quest) => (
+            <li key={quest.id} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span>
+                {quest.name} — {quest.xp} XP [{quest.type}]
+              </span>
+              <button onClick={() => dispatch({ type: 'TOGGLE_QUEST', id: quest.id })}>
+                {quest.active ? 'Disable' : 'Enable'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {/* Award */}
+      <section style={{ padding: 12, background: '#fff', borderRadius: 12, marginBottom: 16 }}>
+        <h2>Award</h2>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: 8,
+          }}
+        >
+          {state.students.map((student) => (
+            <div
+              key={student.id}
+              style={{ border: '1px solid #e2e8f0', borderRadius: 8, padding: 8 }}
+            >
+              <strong>{student.alias}</strong>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 8 }}>
+                {activeQuests.length === 0 && <em>No active quests</em>}
+                {activeQuests.map((quest) => (
+                  <button
+                    key={quest.id}
+                    onClick={() => dispatch({ type: 'AWARD', studentId: student.id, quest })}
+                  >
+                    +{quest.xp} {quest.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div style={{ marginTop: 8 }}>
+          <button onClick={() => dispatch({ type: 'UNDO_LAST' })}>Undo last award</button>
+        </div>
+      </section>
+
+      {/* Log */}
+      <section style={{ padding: 12, background: '#fff', borderRadius: 12 }}>
+        <h2>Recent Log</h2>
+        <ol>
+          {state.logs.slice(0, 10).map((log) => (
+            <li key={log.id}>
+              {new Date(log.timestamp).toLocaleTimeString()} — {log.questName} →{' '}
+              {studentAliasById[log.studentId] ?? log.studentId} (+{log.xp} XP)
+            </li>
+          ))}
+        </ol>
+      </section>
+    </div>
+  );
+}

--- a/classquest/src/app/AppContext.tsx
+++ b/classquest/src/app/AppContext.tsx
@@ -1,0 +1,125 @@
+import React, { createContext, useContext, useEffect, useMemo, useReducer, useRef } from 'react';
+import type { AppState, ID, Quest } from '~/types/models';
+import { DEFAULT_SETTINGS } from '~/core/config';
+import { processAward } from '~/core/gameLogic';
+import { createStorageAdapter } from '~/services/storage';
+import { levelFromXP } from '~/core/xp';
+
+type Action =
+  | { type: 'INIT'; state: AppState }
+  | { type: 'ADD_STUDENT'; alias: string }
+  | { type: 'REMOVE_STUDENT'; id: ID }
+  | { type: 'ADD_QUEST'; quest: Quest }
+  | { type: 'TOGGLE_QUEST'; id: ID }
+  | { type: 'AWARD'; studentId: ID; quest: Quest }
+  | { type: 'UNDO_LAST' }
+  | { type: 'IMPORT'; json: string };
+
+function reducer(state: AppState, a: Action): AppState {
+  switch (a.type) {
+    case 'INIT': {
+      const s = a.state;
+      // migration hook if version changes later
+      return s;
+    }
+    case 'ADD_STUDENT': {
+      const id = globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+      return {
+        ...state,
+        students: [
+          ...state.students,
+          { id, alias: a.alias, xp: 0, level: 1, streaks: {}, lastAwardedDay: {}, badges: [] },
+        ],
+      };
+    }
+    case 'REMOVE_STUDENT':
+      return {
+        ...state,
+        students: state.students.filter((s) => s.id !== a.id),
+        logs: state.logs.filter((l) => l.studentId !== a.id),
+      };
+    case 'ADD_QUEST':
+      return { ...state, quests: [...state.quests, a.quest] };
+    case 'TOGGLE_QUEST':
+      return {
+        ...state,
+        quests: state.quests.map((q) => (q.id === a.id ? { ...q, active: !q.active } : q)),
+      };
+    case 'AWARD': {
+      const next = processAward(state, a.studentId, a.quest);
+      if (next === state || next.logs === state.logs) return next;
+      const latest = next.logs[next.logs.length - 1];
+      if (!latest) return next;
+      const logs = [latest, ...next.logs.slice(0, -1)];
+      return { ...next, logs };
+    }
+    case 'UNDO_LAST': {
+      const [last, ...rest] = state.logs;
+      if (!last) return state;
+      const students = state.students.map((student) => {
+        if (student.id !== last.studentId) return student;
+        const nextXP = state.settings.allowNegativeXP
+          ? student.xp - last.xp
+          : Math.max(0, student.xp - last.xp);
+        return {
+          ...student,
+          xp: nextXP,
+          level: Math.max(1, levelFromXP(Math.max(0, nextXP), state.settings.xpPerLevel)),
+        };
+      });
+      return { ...state, students, logs: rest };
+    }
+    case 'IMPORT':
+      return JSON.parse(a.json) as AppState;
+    default:
+      return state;
+  }
+}
+
+const Ctx = createContext<{ state: AppState; dispatch: React.Dispatch<Action> } | null>(null);
+
+export function AppProvider({ children }: { children: React.ReactNode }) {
+  const storage = useMemo(createStorageAdapter, []);
+  const [state, dispatch] = useReducer(reducer, {
+    students: [],
+    teams: [],
+    quests: [],
+    logs: [],
+    settings: { ...DEFAULT_SETTINGS },
+    version: 1,
+  });
+  const hydratedRef = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const saved = await storage.loadState();
+        if (saved && !cancelled) {
+          dispatch({ type: 'INIT', state: saved });
+        }
+      } finally {
+        if (!cancelled) {
+          hydratedRef.current = true;
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storage]);
+  useEffect(() => {
+    if (!hydratedRef.current) return;
+    (async () => {
+      await storage.saveState(state);
+    })();
+  }, [state, storage]);
+
+  return <Ctx.Provider value={{ state, dispatch }}>{children}</Ctx.Provider>;
+}
+
+export const useApp = () => {
+  const v = useContext(Ctx);
+  if (!v) throw new Error('AppContext missing');
+  return v;
+};

--- a/classquest/src/main.tsx
+++ b/classquest/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { AppProvider } from './app/AppContext';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <AppProvider>
+      <App />
+    </AppProvider>
   </React.StrictMode>,
 );

--- a/classquest/src/services/storage/index.ts
+++ b/classquest/src/services/storage/index.ts
@@ -1,0 +1,5 @@
+import { LocalStorageAdapter } from './localStorage';
+
+export type StorageAdapter = LocalStorageAdapter;
+
+export const createStorageAdapter = () => new LocalStorageAdapter();


### PR DESCRIPTION
## Summary
- add an AppContext provider with reducer actions for students, quests, awards, undo, and persistence
- wire the provider into the entrypoint and build a simple app UI to exercise the new actions
- expose a storage adapter factory for the context to use

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb033b86bc832c855ca6a87127247b