### PR TITLE
Implement Phase 4 teacher UI

### DIFF
--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -3,4 +3,5 @@ export const DEFAULT_SETTINGS = {
   xpPerLevel: 100,
   streakThresholdForBadge: 5,
   allowNegativeXP: false,
+  onboardingCompleted: false,
 } as const;

--- a/classquest/src/index.css
+++ b/classquest/src/index.css
@@ -24,3 +24,14 @@ body {
   background: #f8fafc;
   color: #0f172a;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -22,7 +22,11 @@ export type LogEntry = {
 };
 
 export type Settings = {
-  className: string; xpPerLevel: number; streakThresholdForBadge: number; allowNegativeXP?: boolean;
+  className: string;
+  xpPerLevel: number;
+  streakThresholdForBadge: number;
+  allowNegativeXP?: boolean;
+  onboardingCompleted?: boolean;
 };
 
 export type AppState = {

--- a/classquest/src/ui/components/LeaderboardRow.tsx
+++ b/classquest/src/ui/components/LeaderboardRow.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+type Props = { rank:number; name:string; xp:number; maxXp:number };
+function RowBase({ rank, name, xp, maxXp }: Props){
+  const pct = maxXp ? Math.min(100, Math.round((xp / maxXp) * 100)) : 0;
+  return (
+    <div style={{ display:'grid', gridTemplateColumns:'48px 1fr 100px', alignItems:'center', gap:8, padding:'6px 8px' }}>
+      <div style={{ opacity:.7 }}>#{rank}</div>
+      <div>
+        <div style={{ display:'flex', justifyContent:'space-between' }}>
+          <strong>{name}</strong><span style={{ opacity:.7 }}>{xp} XP</span>
+        </div>
+        <div style={{ height:8, background:'#eef2f7', borderRadius:8, overflow:'hidden' }}>
+          <div style={{ width:`${pct}%`, height:'100%', background:'var(--color-primary)' }} aria-hidden />
+        </div>
+      </div>
+      <div style={{ textAlign:'right' }}>{pct}%</div>
+    </div>
+  );
+}
+export const LeaderboardRow = React.memo(RowBase);

--- a/classquest/src/ui/components/LogItem.tsx
+++ b/classquest/src/ui/components/LogItem.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+type Props = { time:string; studentAlias:string; questName:string; xp:number };
+function ItemBase({ time, studentAlias, questName, xp }: Props){
+  return (
+    <li style={{ padding:'6px 0' }}>
+      <span style={{ opacity:.7, marginRight:8 }}>{time}</span>
+      <strong>{questName}</strong> → {studentAlias} (+{xp} XP)
+    </li>
+  );
+}
+export const LogItem = React.memo(ItemBase);

--- a/classquest/src/ui/components/StudentTile.tsx
+++ b/classquest/src/ui/components/StudentTile.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+
+type Props = {
+  id: string;
+  alias: string;
+  xp: number;
+  level: number;
+  selected: boolean;
+  onSelect: (id: string) => void;
+  onFocus?: () => void;
+  children?: React.ReactNode;
+};
+
+const TileInner = React.forwardRef<HTMLDivElement, Props>(function TileBase(
+  { id, alias, xp, level, selected, onSelect, onFocus, children },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(id)}
+      onKeyDown={(e) => {
+        if (e.key === ' ' || e.key === 'Enter') {
+          e.preventDefault();
+          onSelect(id);
+        }
+      }}
+      onFocus={onFocus}
+      aria-pressed={selected}
+      aria-label={`Schüler ${alias}, ${xp} XP, Level ${level}${selected ? ', ausgewählt' : ''}`}
+      style={{
+        border: selected ? '2px solid var(--color-primary)' : '1px solid #e2e8f0',
+        borderRadius: 12,
+        padding: 14,
+        background: '#fff',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        minHeight: 140,
+        cursor: 'pointer',
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+        <strong style={{ fontSize: '1.1rem' }}>{alias}</strong>
+        <span style={{ fontSize: 12, opacity: 0.8 }}>{xp} XP · L{level}</span>
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>{children}</div>
+    </div>
+  );
+});
+
+TileInner.displayName = 'StudentTile';
+
+export const StudentTile = React.memo(TileInner);

--- a/classquest/src/ui/hooks/useSelection.ts
+++ b/classquest/src/ui/hooks/useSelection.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react';
+
+export function useSelection<T extends string>(initial: T[] = []) {
+  const [selected, setSelected] = useState<Set<T>>(new Set(initial));
+  const isSelected = useCallback((id: T) => selected.has(id), [selected]);
+  const toggle = useCallback((id: T) => {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }, []);
+  const clear = useCallback(() => setSelected(new Set()), []);
+  const setMany = useCallback((ids: T[]) => setSelected(new Set(ids)), []);
+  return { selected, isSelected, toggle, clear, setMany };
+}

--- a/classquest/src/ui/hooks/useUndoToast.tsx
+++ b/classquest/src/ui/hooks/useUndoToast.tsx
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react';
+
+export function useUndoToast() {
+  const [message, setMessage] = useState<string | null>(null);
+  useEffect(() => {
+    if (!message) return;
+    const t = setTimeout(() => setMessage(null), 4000);
+    return () => clearTimeout(t);
+  }, [message]);
+  return { message, setMessage, clear: () => setMessage(null) };
+}

--- a/classquest/src/ui/screens/AwardScreen.tsx
+++ b/classquest/src/ui/screens/AwardScreen.tsx
@@ -1,0 +1,330 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import { StudentTile } from '~/ui/components/StudentTile';
+import { useSelection } from '~/ui/hooks/useSelection';
+import { useUndoToast } from '~/ui/hooks/useUndoToast';
+import type { Quest } from '~/types/models';
+
+const TILE_MIN_WIDTH = 240;
+
+export default function AwardScreen() {
+  const { state, dispatch } = useApp();
+  const quests = useMemo(() => state.quests.filter((q) => q.active), [state.quests]);
+  const { selected, isSelected, toggle, clear, setMany } = useSelection<string>([]);
+  const [focusedIdx, setFocusedIdx] = useState(0);
+  const [activeQuestId, setActiveQuestId] = useState<string | null>(null);
+  const [columns, setColumns] = useState(3);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const tileRefs = useRef<Array<HTMLDivElement | null>>([]);
+  const { message, setMessage, clear: clearToast } = useUndoToast();
+
+  const students = state.students;
+  const aliasById = useMemo(() => new Map(students.map((s) => [s.id, s.alias])), [students]);
+  const activeQuest = useMemo(() => quests.find((q) => q.id === activeQuestId) ?? quests[0] ?? null, [quests, activeQuestId]);
+
+  useEffect(() => {
+    if (!quests.length) {
+      setActiveQuestId(null);
+      return;
+    }
+    if (!activeQuestId || !quests.some((q) => q.id === activeQuestId)) {
+      setActiveQuestId(quests[0].id);
+    }
+  }, [quests, activeQuestId]);
+
+  const computeColumns = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const width = gridRef.current?.clientWidth ?? window.innerWidth;
+    const next = Math.max(2, Math.min(5, Math.floor(width / TILE_MIN_WIDTH)));
+    setColumns(next || 2);
+  }, []);
+
+  useEffect(() => {
+    computeColumns();
+    if (typeof window === 'undefined') return;
+    window.addEventListener('resize', computeColumns);
+    return () => window.removeEventListener('resize', computeColumns);
+  }, [computeColumns]);
+
+  useEffect(() => {
+    computeColumns();
+  }, [students.length, computeColumns]);
+
+  useEffect(() => {
+    if (focusedIdx >= students.length) {
+      setFocusedIdx(students.length ? students.length - 1 : 0);
+    }
+  }, [students.length, focusedIdx]);
+
+  useEffect(() => {
+    const node = tileRefs.current[focusedIdx];
+    if (node) {
+      node.focus({ preventScroll: true });
+    }
+  }, [focusedIdx, students.length]);
+
+  useEffect(() => {
+    tileRefs.current = tileRefs.current.slice(0, students.length);
+  }, [students.length]);
+
+  const setFocus = useCallback(
+    (updater: (current: number) => number) => {
+      setFocusedIdx((prev) => {
+        const next = updater(prev);
+        return Math.min(Math.max(next, 0), Math.max(0, students.length - 1));
+      });
+    },
+    [students.length],
+  );
+
+  const showUndoToast = useCallback(
+    (quest: Quest, target: string) => {
+      setMessage(`${quest.name} an ${target} vergeben. Drücke U zum Rückgängig machen.`);
+    },
+    [setMessage],
+  );
+
+  const awardStudent = useCallback(
+    (studentId: string, quest: Quest) => {
+      dispatch({ type: 'AWARD', studentId, quest });
+    },
+    [dispatch],
+  );
+
+  const awardSelected = useCallback(() => {
+    if (!activeQuest) return;
+    const ids = students.filter((s) => selected.has(s.id)).map((s) => s.id);
+    if (!ids.length) return;
+    ids.forEach((id) => awardStudent(id, activeQuest));
+    const target = ids.length === 1 ? aliasById.get(ids[0]) ?? 'Schüler' : `${ids.length} Schüler`;
+    showUndoToast(activeQuest, target);
+  }, [activeQuest, students, selected, awardStudent, aliasById, showUndoToast]);
+
+  const awardSingle = useCallback(
+    (studentId: string, quest: Quest) => {
+      awardStudent(studentId, quest);
+      const target = aliasById.get(studentId) ?? 'Schüler';
+      showUndoToast(quest, target);
+    },
+    [awardStudent, aliasById, showUndoToast],
+  );
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!students.length) return;
+      const rowLen = columns || 1;
+      switch (e.key) {
+        case 'ArrowRight':
+          e.preventDefault();
+          setFocus((i) => i + 1);
+          break;
+        case 'ArrowLeft':
+          e.preventDefault();
+          setFocus((i) => i - 1);
+          break;
+        case 'ArrowDown':
+          e.preventDefault();
+          setFocus((i) => i + rowLen);
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setFocus((i) => i - rowLen);
+          break;
+        case 'Enter':
+          if (activeQuest) {
+            e.preventDefault();
+            const student = students[focusedIdx];
+            if (student) {
+              awardSingle(student.id, activeQuest);
+            }
+          }
+          break;
+        default:
+          if (e.key.toLowerCase() === 'u') {
+            e.preventDefault();
+            dispatch({ type: 'UNDO_LAST' });
+            clearToast();
+          }
+          break;
+      }
+    },
+    [students, columns, activeQuest, awardSingle, focusedIdx, dispatch, setFocus, clearToast],
+  );
+
+  const selectAll = useCallback(() => setMany(students.map((s) => s.id)), [students, setMany]);
+
+  const selectedCount = selected.size;
+
+  return (
+    <div onKeyDown={onKeyDown}>
+      <div style={{ position: 'sticky', top: 0, background: '#f8fafc', padding: '12px 0', zIndex: 1 }}>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 12,
+            alignItems: 'center',
+          }}
+        >
+          <div role="radiogroup" aria-label="Aktive Quest" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {quests.length ? (
+              quests.map((q) => (
+                <button
+                  type="button"
+                  key={q.id}
+                  role="radio"
+                  aria-checked={activeQuest?.id === q.id}
+                  onClick={() => setActiveQuestId(q.id)}
+                  style={{
+                    padding: '10px 16px',
+                    borderRadius: 999,
+                    border: activeQuest?.id === q.id ? '2px solid var(--color-primary)' : '1px solid #cbd5f5',
+                    background: activeQuest?.id === q.id ? 'rgba(91,141,239,0.12)' : '#fff',
+                    fontWeight: 600,
+                    cursor: 'pointer',
+                  }}
+                >
+                  +{q.xp} {q.name}
+                </button>
+              ))
+            ) : (
+              <em>Keine aktiven Quests</em>
+            )}
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginLeft: 'auto', flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              onClick={awardSelected}
+              disabled={!activeQuest || selectedCount === 0}
+              aria-disabled={!activeQuest || selectedCount === 0}
+              style={{
+                padding: '10px 18px',
+                borderRadius: 12,
+                background: 'var(--color-primary)',
+                color: '#fff',
+                fontWeight: 600,
+                border: 'none',
+                minWidth: 200,
+                cursor: !activeQuest || selectedCount === 0 ? 'not-allowed' : 'pointer',
+                opacity: !activeQuest || selectedCount === 0 ? 0.6 : 1,
+              }}
+            >
+              Allen ausgewählten vergeben
+            </button>
+            <span aria-live="polite" style={{ fontWeight: 600 }}>
+              Ausgewählt: {selectedCount}
+            </span>
+            <button type="button" onClick={selectAll} aria-label="Alle Schüler auswählen">
+              Alle auswählen
+            </button>
+            <button type="button" onClick={clear} aria-label="Auswahl leeren">
+              Auswahl leeren
+            </button>
+            <button
+              type="button"
+              onClick={() => dispatch({ type: 'UNDO_LAST' })}
+              aria-label="Letzte Vergabe rückgängig machen"
+            >
+              Undo
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div
+        ref={gridRef}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${Math.max(1, columns)}, minmax(220px, 1fr))`,
+          gap: 14,
+          alignItems: 'stretch',
+          paddingTop: 12,
+        }}
+      >
+        {students.map((s, idx) => (
+          <div
+            key={s.id}
+            onFocusCapture={() => setFocusedIdx(idx)}
+            style={{
+              outline: idx === focusedIdx ? '3px solid rgba(0,194,255,0.6)' : 'none',
+              borderRadius: 16,
+              transition: 'outline 0.1s ease-in-out',
+            }}
+          >
+            <StudentTile
+              ref={(node) => {
+                tileRefs.current[idx] = node;
+              }}
+              id={s.id}
+              alias={s.alias}
+              xp={s.xp}
+              level={s.level}
+              selected={isSelected(s.id)}
+              onSelect={toggle}
+            >
+              {quests.map((q) => (
+                <button
+                  type="button"
+                  key={q.id}
+                  onClick={() => awardSingle(s.id, q)}
+                  style={{
+                    padding: '8px 10px',
+                    borderRadius: 999,
+                    border: '1px solid #dbe3f4',
+                    background: '#f8fbff',
+                    cursor: 'pointer',
+                  }}
+                  aria-label={`${q.name} an ${s.alias} vergeben`}
+                >
+                  +{q.xp}
+                </button>
+              ))}
+            </StudentTile>
+          </div>
+        ))}
+      </div>
+
+      {message && (
+        <div
+          role="status"
+          aria-live="assertive"
+          style={{
+            position: 'fixed',
+            bottom: 24,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#1e293b',
+            color: '#fff',
+            padding: '12px 20px',
+            borderRadius: 12,
+            display: 'flex',
+            gap: 12,
+            alignItems: 'center',
+            boxShadow: '0 10px 30px rgba(15, 23, 42, 0.35)',
+            zIndex: 5,
+          }}
+        >
+          <span>{message}</span>
+          <button
+            type="button"
+            onClick={() => {
+              dispatch({ type: 'UNDO_LAST' });
+              clearToast();
+            }}
+            style={{
+              background: '#fff',
+              color: '#1e293b',
+              borderRadius: 8,
+              padding: '6px 12px',
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: 600,
+            }}
+          >
+            Rückgängig
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/FirstRunWizard.tsx
+++ b/classquest/src/ui/screens/FirstRunWizard.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import { useApp } from '~/app/AppContext';
+
+export default function FirstRunWizard({ onDone }: { onDone: () => void }) {
+  const { state, dispatch } = useApp();
+  const [name, setName] = useState(state.settings.className || 'Meine Klasse');
+  const handleSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    const trimmed = name.trim() || 'Meine Klasse';
+    setName(trimmed);
+    dispatch({
+      type: 'UPDATE_SETTINGS',
+      updates: { className: trimmed, onboardingCompleted: true },
+    });
+    onDone();
+  };
+  return (
+    <div style={{ maxWidth: 640, margin: '40px auto', background: '#fff', borderRadius: 16, padding: 16 }}>
+      <h1>Willkommen zu ClassQuest</h1>
+      <p>Lege einen Klassen​namen fest.</p>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <label>
+          <span className="sr-only">Klassenname</span>
+          <input
+            aria-label="Klassenname"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+          />
+        </label>
+        <div>
+          <button type="submit">Weiter</button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/LeaderboardScreen.tsx
+++ b/classquest/src/ui/screens/LeaderboardScreen.tsx
@@ -1,0 +1,33 @@
+import React, { useMemo, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import { LeaderboardRow } from '~/ui/components/LeaderboardRow';
+
+export default function LeaderboardScreen(){
+  const { state } = useApp();
+  const [sort, setSort] = useState<'name'|'xp'>('xp');
+
+  const rows = useMemo(()=>{
+    const list = state.students.map(s=>({ name: s.alias, xp: s.xp }));
+    list.sort((a,b)=> sort==='xp' ? (b.xp-a.xp) : a.name.localeCompare(b.name));
+    return list;
+  }, [state.students, sort]);
+
+  const maxXp = rows[0]?.xp ?? 0;
+
+  return (
+    <div>
+      <div style={{ display:'flex', gap:8, alignItems:'center' }}>
+        <h2>Leaderboard</h2>
+        <div role="group" aria-label="Sortierung">
+          <button type="button" onClick={()=>setSort('xp')} aria-pressed={sort==='xp'}>nach XP</button>
+          <button type="button" onClick={()=>setSort('name')} aria-pressed={sort==='name'}>nach Name</button>
+        </div>
+      </div>
+      <div style={{ background:'#fff', borderRadius:12, padding:8 }}>
+        {rows.map((r, i)=>(
+          <LeaderboardRow key={r.name} rank={i+1} name={r.name} xp={r.xp} maxXp={maxXp} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/LogScreen.tsx
+++ b/classquest/src/ui/screens/LogScreen.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import { LogItem } from '~/ui/components/LogItem';
+
+function startOfDay(d=new Date()){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
+function startOfWeek(d=new Date()){ const x=startOfDay(d); const diff=(x.getDay()+6)%7; x.setDate(x.getDate()-diff); return x; }
+
+export default function LogScreen(){
+  const { state } = useApp();
+  const [studentFilter, setStudentFilter] = useState<string>('');
+  const [questFilter, setQuestFilter] = useState<string>('');
+  const [period, setPeriod] = useState<'today'|'week'|'all'>('all');
+
+  const studentsById = useMemo(()=>Object.fromEntries(state.students.map(s=>[s.id,s.alias])), [state.students]);
+  const tsMin = period==='today' ? startOfDay().getTime() : period==='week' ? startOfWeek().getTime() : 0;
+
+  const entries = useMemo(()=>{
+    return state.logs
+      .filter(l => (!studentFilter || l.studentId===studentFilter)
+        && (!questFilter || l.questId===questFilter)
+        && (l.timestamp>=tsMin))
+      .slice(0, 500); // cap render work
+  }, [state.logs, studentFilter, questFilter, tsMin]);
+
+  return (
+    <div>
+      <h2>Protokoll</h2>
+      <div style={{ display:'flex', gap:8, flexWrap:'wrap' }}>
+        <select aria-label="Filter Schüler" value={studentFilter} onChange={e=>setStudentFilter(e.target.value)}>
+          <option value=''>Alle Schüler</option>
+          {state.students.map(s=><option key={s.id} value={s.id}>{s.alias}</option>)}
+        </select>
+        <select aria-label="Filter Quest" value={questFilter} onChange={e=>setQuestFilter(e.target.value)}>
+          <option value=''>Alle Quests</option>
+          {state.quests.map(q=><option key={q.id} value={q.id}>{q.name}</option>)}
+        </select>
+        <select aria-label="Zeitraum" value={period} onChange={e=>setPeriod(e.target.value as any)}>
+          <option value='today'>Heute</option>
+          <option value='week'>Diese Woche</option>
+          <option value='all'>Gesamt</option>
+        </select>
+      </div>
+      <ol style={{ background:'#fff', borderRadius:12, padding:'8px 12px', maxHeight: '60vh', overflow:'auto' }}>
+        {entries.map(l=>(
+          <LogItem key={l.id}
+            time={new Date(l.timestamp).toLocaleTimeString()}
+            studentAlias={studentsById[l.studentId] ?? l.studentId}
+            questName={l.questName} xp={l.xp}
+          />
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/ManageScreen.tsx
+++ b/classquest/src/ui/screens/ManageScreen.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import type { Quest } from '~/types/models';
+
+function makeId() {
+  return globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+function newQuest(
+  name: string,
+  xp: number,
+  type: 'daily' | 'repeatable' | 'oneoff' = 'daily',
+): Quest {
+  return { id: makeId(), name, xp, type, target: 'individual', active: true };
+}
+
+type StudentRowProps = {
+  id: string;
+  alias: string;
+  onSave: (id: string, alias: string) => void;
+  onRemove: (id: string) => void;
+};
+
+const StudentRow = React.memo(function StudentRow({ id, alias, onSave, onRemove }: StudentRowProps) {
+  const [value, setValue] = useState(alias);
+  useEffect(() => setValue(alias), [alias]);
+
+  const commit = useCallback(() => {
+    const trimmed = value.trim();
+    if (!trimmed || trimmed === alias) {
+      setValue(alias);
+      return;
+    }
+    onSave(id, trimmed);
+  }, [value, alias, onSave, id]);
+
+  return (
+    <li style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      <input
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            commit();
+          }
+        }}
+        aria-label={`Alias für ${alias} bearbeiten`}
+        style={{ flex: 1, padding: '6px 8px', borderRadius: 8, border: '1px solid #d0d7e6' }}
+      />
+      <button type="button" onClick={commit} aria-label={`Alias von ${alias} speichern`} style={{ padding: '6px 12px' }}>
+        Speichern
+      </button>
+      <button
+        type="button"
+        onClick={() => onRemove(id)}
+        aria-label={`${alias} entfernen`}
+        style={{ padding: '6px 12px' }}
+      >
+        Entfernen
+      </button>
+    </li>
+  );
+});
+
+StudentRow.displayName = 'StudentRow';
+
+type QuestRowProps = {
+  quest: Quest;
+  onSave: (id: string, updates: Partial<Pick<Quest, 'name' | 'xp' | 'type' | 'active'>>) => void;
+  onRemove: (id: string) => void;
+};
+
+const QuestRow = React.memo(function QuestRow({ quest, onSave, onRemove }: QuestRowProps) {
+  const [name, setName] = useState(quest.name);
+  const [xp, setXp] = useState<number>(quest.xp);
+  const [type, setType] = useState<Quest['type']>(quest.type);
+  const [active, setActive] = useState<boolean>(quest.active);
+
+  useEffect(() => setName(quest.name), [quest.name]);
+  useEffect(() => setXp(quest.xp), [quest.xp]);
+  useEffect(() => setType(quest.type), [quest.type]);
+  useEffect(() => setActive(quest.active), [quest.active]);
+
+  const commit = useCallback(() => {
+    onSave(quest.id, { name: name.trim() || quest.name, xp: Math.max(0, xp), type, active });
+  }, [onSave, quest.id, name, xp, type, active, quest.name]);
+
+  return (
+    <li style={{ display: 'grid', gridTemplateColumns: '2fr 100px 120px auto auto', gap: 8, alignItems: 'center' }}>
+      <input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            commit();
+          }
+        }}
+        aria-label={`Quest ${quest.name} umbenennen`}
+        style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #d0d7e6' }}
+      />
+      <input
+        type="number"
+        value={xp}
+        min={0}
+        onChange={(e) => setXp(Math.max(0, Number.parseInt(e.target.value, 10) || 0))}
+        onBlur={commit}
+        aria-label={`XP für ${quest.name}`}
+        style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #d0d7e6' }}
+      />
+      <select
+        value={type}
+        onChange={(e) => {
+          const next = e.target.value as Quest['type'];
+          setType(next);
+          onSave(quest.id, { type: next });
+        }}
+        aria-label={`Questtyp für ${quest.name}`}
+        style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #d0d7e6' }}
+      >
+        <option value="daily">daily</option>
+        <option value="repeatable">repeatable</option>
+        <option value="oneoff">oneoff</option>
+      </select>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <input
+          type="checkbox"
+          checked={active}
+          onChange={(e) => {
+            const checked = e.target.checked;
+            setActive(checked);
+            onSave(quest.id, { active: checked });
+          }}
+          aria-label={`${quest.name} aktiv schalten`}
+        />
+        Aktiv
+      </label>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <button type="button" onClick={commit} aria-label={`Quest ${quest.name} speichern`} style={{ padding: '6px 12px' }}>
+          Speichern
+        </button>
+        <button
+          type="button"
+          onClick={() => onRemove(quest.id)}
+          aria-label={`Quest ${quest.name} löschen`}
+          style={{ padding: '6px 12px' }}
+        >
+          Löschen
+        </button>
+      </div>
+    </li>
+  );
+});
+
+QuestRow.displayName = 'QuestRow';
+
+export default function ManageScreen() {
+  const { state, dispatch } = useApp();
+  const [alias, setAlias] = useState('');
+  const [qName, setQName] = useState('Hausaufgaben');
+  const [qXP, setQXP] = useState(10);
+  const [qType, setQType] = useState<'daily' | 'repeatable' | 'oneoff'>('daily');
+
+  const addStudent = useCallback(() => {
+    if (!alias.trim()) return;
+    dispatch({ type: 'ADD_STUDENT', alias: alias.trim() });
+    setAlias('');
+  }, [alias, dispatch]);
+
+  const populateStudents = useCallback(() => {
+    for (let i = 1; i <= 30; i++) {
+      dispatch({ type: 'ADD_STUDENT', alias: `S${String(i).padStart(2, '0')}` });
+    }
+  }, [dispatch]);
+
+  const addQuest = useCallback(() => {
+    if (!qName.trim()) return;
+    dispatch({ type: 'ADD_QUEST', quest: newQuest(qName.trim(), qXP, qType) });
+  }, [dispatch, qName, qXP, qType]);
+
+  const populateQuests = useCallback(() => {
+    const presets = Array.from({ length: 15 }, (_, i) =>
+      newQuest(`Quest ${i + 1}`, 5 + ((i * 5) % 30), (i % 3 === 0 ? 'daily' : i % 3 === 1 ? 'repeatable' : 'oneoff')),
+    );
+    presets.forEach((quest) => dispatch({ type: 'ADD_QUEST', quest }));
+  }, [dispatch]);
+
+  const onUpdateStudent = useCallback(
+    (id: string, nextAlias: string) => dispatch({ type: 'UPDATE_STUDENT_ALIAS', id, alias: nextAlias }),
+    [dispatch],
+  );
+  const onRemoveStudent = useCallback((id: string) => dispatch({ type: 'REMOVE_STUDENT', id }), [dispatch]);
+  const onUpdateQuest = useCallback(
+    (id: string, updates: Partial<Pick<Quest, 'name' | 'xp' | 'type' | 'active'>>) =>
+      dispatch({ type: 'UPDATE_QUEST', id, updates }),
+    [dispatch],
+  );
+  const onRemoveQuest = useCallback((id: string) => dispatch({ type: 'REMOVE_QUEST', id }), [dispatch]);
+
+  const sortedQuests = useMemo(() => [...state.quests].sort((a, b) => a.name.localeCompare(b.name)), [state.quests]);
+  const sortedStudents = useMemo(() => [...state.students].sort((a, b) => a.alias.localeCompare(b.alias)), [state.students]);
+
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      <section style={{ background: '#fff', padding: 16, borderRadius: 16 }}>
+        <h2>Schüler verwalten</h2>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+          <input
+            aria-label="Neuen Schüleralias"
+            placeholder="Alias"
+            value={alias}
+            onChange={(e) => setAlias(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') addStudent();
+            }}
+            style={{ flex: 1, minWidth: 180, padding: '8px 10px', borderRadius: 10, border: '1px solid #cbd5f5' }}
+          />
+          <button type="button" onClick={addStudent} style={{ padding: '10px 16px' }}>
+            Hinzufügen
+          </button>
+          <button type="button" onClick={populateStudents} style={{ padding: '10px 16px' }}>
+            Demo: 30 Schüler
+          </button>
+        </div>
+        <ul style={{ display: 'grid', gap: 8, margin: 0, padding: 0, listStyle: 'none' }}>
+          {sortedStudents.map((s) => (
+            <StudentRow key={s.id} id={s.id} alias={s.alias} onSave={onUpdateStudent} onRemove={onRemoveStudent} />
+          ))}
+        </ul>
+      </section>
+
+      <section style={{ background: '#fff', padding: 16, borderRadius: 16 }}>
+        <h2>Quests verwalten</h2>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
+          <input
+            aria-label="Questname"
+            value={qName}
+            onChange={(e) => setQName(e.target.value)}
+            style={{ flex: 2, minWidth: 160, padding: '8px 10px', borderRadius: 10, border: '1px solid #cbd5f5' }}
+          />
+          <input
+            aria-label="XP"
+            type="number"
+            min={0}
+            value={qXP}
+            onChange={(e) => setQXP(Number.parseInt(e.target.value, 10) || 0)}
+            style={{ width: 100, padding: '8px 10px', borderRadius: 10, border: '1px solid #cbd5f5' }}
+          />
+          <select
+            aria-label="Questtyp"
+            value={qType}
+            onChange={(e) => setQType(e.target.value as typeof qType)}
+            style={{ minWidth: 140, padding: '8px 10px', borderRadius: 10, border: '1px solid #cbd5f5' }}
+          >
+            <option value="daily">daily</option>
+            <option value="repeatable">repeatable</option>
+            <option value="oneoff">oneoff</option>
+          </select>
+          <button type="button" onClick={addQuest} style={{ padding: '10px 16px' }}>
+            Quest anlegen
+          </button>
+          <button type="button" onClick={populateQuests} style={{ padding: '10px 16px' }}>
+            Demo: 15 Quests
+          </button>
+        </div>
+        <ul style={{ display: 'grid', gap: 8, margin: 0, padding: 0, listStyle: 'none' }}>
+          {sortedQuests.map((quest) => (
+            <QuestRow key={quest.id} quest={quest} onSave={onUpdateQuest} onRemove={onRemoveQuest} />
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the app shell with tabbed navigation and persist onboarding completion so the first-run wizard leads teachers into the management view
- build memoized UI components and screens for awarding, leaderboard, log, and management workflows, complete with keyboard support, undo toasts, and demo data helpers
- extend the app context with update and remove actions, including a settings update hook that stores the onboarding flag

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb094520cc832c96e2900fdd0ef7d8