### PR TITLE
Add quest-first awarding, groups, and backup tools

### DIFF
--- a/classquest/src/ui/components/StudentTile.tsx
+++ b/classquest/src/ui/components/StudentTile.tsx
@@ -6,47 +6,86 @@ type Props = {
   xp: number;
   level: number;
   selected: boolean;
-  onSelect: (id: string) => void;
+  disabled?: boolean;
+  onToggleSelect: (id: string) => void;
+  onAward: (id: string) => void;
   onFocus?: () => void;
-  children?: React.ReactNode;
 };
 
 const TileInner = React.forwardRef<HTMLDivElement, Props>(function TileBase(
-  { id, alias, xp, level, selected, onSelect, onFocus, children },
+  { id, alias, xp, level, selected, disabled, onToggleSelect, onAward, onFocus },
   ref,
 ) {
   return (
     <div
       ref={ref}
-      role="checkbox" // Korrekte Rolle für ein auswählbares Element
+      role="button"
       tabIndex={0}
-      onClick={() => onSelect(id)}
-      onKeyDown={(e) => {
-        if (e.key === ' ' || e.key === 'Enter') {
-          e.preventDefault();
-          onSelect(id);
+      onClick={() => {
+        if (!disabled) {
+          onAward(id);
+        }
+      }}
+      onKeyDown={(event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && !disabled) {
+          event.preventDefault();
+          onAward(id);
+          return;
+        }
+        if (event.key.toLowerCase() === 's') {
+          event.preventDefault();
+          onToggleSelect(id);
         }
       }}
       onFocus={onFocus}
-      aria-checked={selected} // Passendes Attribut für role="checkbox"
-      aria-label={`Schüler ${alias}, ${xp} XP, Level ${level}${selected ? ', ausgewählt' : ''}`}
+      aria-pressed={selected}
+      aria-disabled={disabled || undefined}
+      aria-label={`Schüler ${alias}, ${xp} XP, Level ${level}${selected ? ', ausgewählt' : ''}${disabled ? '. Quest wählen' : ''}`}
       style={{
         border: selected ? '2px solid var(--color-primary)' : '1px solid #e2e8f0',
         borderRadius: 12,
-        padding: 14,
+        padding: 16,
         background: '#fff',
         display: 'flex',
         flexDirection: 'column',
-        gap: 8,
-        minHeight: 140,
-        cursor: 'pointer',
+        gap: 12,
+        minHeight: 150,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.7 : 1,
+        boxShadow: selected ? '0 0 0 4px rgba(91,141,239,0.15)' : 'none',
+        transition: 'box-shadow 0.15s ease, border 0.15s ease',
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8 }}>
         <strong style={{ fontSize: '1.1rem' }}>{alias}</strong>
-        <span style={{ fontSize: 12, opacity: 0.8 }}>{xp} XP · L{level}</span>
+        <span style={{ fontSize: 12, opacity: 0.75 }}>{xp} XP · L{level}</span>
       </div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>{children}</div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleSelect(id);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === ' ') {
+              event.preventDefault();
+            }
+          }}
+          aria-pressed={selected}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 999,
+            border: '1px solid #cbd5f5',
+            background: selected ? 'rgba(91,141,239,0.15)' : '#f8fbff',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {selected ? 'Ausgewählt' : 'Auswählen'}
+        </button>
+        {disabled ? <span style={{ fontSize: 12, color: '#64748b' }}>Quest wählen</span> : <span style={{ fontSize: 12, color: '#64748b' }}>S = Auswahl</span>}
+      </div>
     </div>
   );
 });

--- a/classquest/src/ui/screens/AwardScreen.tsx
+++ b/classquest/src/ui/screens/AwardScreen.tsx
@@ -3,9 +3,43 @@ import { useApp } from '~/app/AppContext';
 import { StudentTile } from '~/ui/components/StudentTile';
 import { useSelection } from '~/ui/hooks/useSelection';
 import { useUndoToast } from '~/ui/hooks/useUndoToast';
-import type { Quest } from '~/types/models';
+import type { Quest, Team } from '~/types/models';
 
 const TILE_MIN_WIDTH = 240;
+
+type GroupChipProps = {
+  team: Team;
+  membersCount: number;
+  disabled: boolean;
+  onAward: (teamId: string) => void;
+};
+
+const GroupChip = React.memo(function GroupChip({ team, membersCount, disabled, onAward }: GroupChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onAward(team.id)}
+      disabled={disabled || membersCount === 0}
+      style={{
+        padding: '8px 14px',
+        borderRadius: 999,
+        border: '1px solid #cbd5f5',
+        background: disabled || membersCount === 0 ? '#f1f5f9' : '#f8fbff',
+        fontWeight: 600,
+        cursor: disabled || membersCount === 0 ? 'not-allowed' : 'pointer',
+        opacity: disabled ? 0.6 : 1,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}
+      aria-label={`Quest an ${team.name} vergeben (${membersCount} Mitglieder)`}
+    >
+      <span>{team.name}</span>
+      <span style={{ fontSize: 12, opacity: 0.7 }}>({membersCount})</span>
+    </button>
+  );
+});
+GroupChip.displayName = 'GroupChip';
 
 export default function AwardScreen() {
   const { state, dispatch } = useApp();
@@ -19,8 +53,12 @@ export default function AwardScreen() {
   const { message, setMessage, clear: clearToast } = useUndoToast();
 
   const students = state.students;
+  const studentIdSet = useMemo(() => new Set(students.map((student) => student.id)), [students]);
   const aliasById = useMemo(() => new Map(students.map((s) => [s.id, s.alias])), [students]);
-  const activeQuest = useMemo(() => quests.find((q) => q.id === activeQuestId) ?? quests[0] ?? null, [quests, activeQuestId]);
+  const activeQuest = useMemo(
+    () => quests.find((q) => q.id === activeQuestId) ?? quests[0] ?? null,
+    [quests, activeQuestId],
+  );
 
   useEffect(() => {
     if (!quests.length) {
@@ -86,7 +124,6 @@ export default function AwardScreen() {
 
   const awardStudent = useCallback(
     (studentId: string, quest: Quest) => {
-      // Korrekte Payload-Struktur für den Reducer
       dispatch({ type: 'AWARD', payload: { questId: quest.id, studentId } });
     },
     [dispatch],
@@ -102,12 +139,40 @@ export default function AwardScreen() {
   }, [activeQuest, students, selected, awardStudent, aliasById, showUndoToast]);
 
   const awardSingle = useCallback(
-    (studentId: string, quest: Quest) => {
-      awardStudent(studentId, quest);
+    (studentId: string) => {
+      if (!activeQuest) return;
+      awardStudent(studentId, activeQuest);
       const target = aliasById.get(studentId) ?? 'Schüler';
-      showUndoToast(quest, target);
+      showUndoToast(activeQuest, target);
     },
-    [awardStudent, aliasById, showUndoToast],
+    [activeQuest, awardStudent, aliasById, showUndoToast],
+  );
+
+  const groups = useMemo(() => {
+    if (!state.teams.length) return [] as Array<Team & { memberIds: string[] }>;
+    return state.teams.map((team) => ({
+      ...team,
+      memberIds: team.memberIds.filter((memberId) => studentIdSet.has(memberId)),
+    }));
+  }, [state.teams, studentIdSet]);
+
+  const awardGroup = useCallback(
+    (teamId: string) => {
+      if (!activeQuest) return;
+      const team = groups.find((t) => t.id === teamId);
+      if (!team) return;
+      if (activeQuest.target === 'team') {
+        dispatch({ type: 'AWARD', payload: { questId: activeQuest.id, teamId: team.id } });
+        showUndoToast(activeQuest, team.name);
+        return;
+      }
+      const members = team.memberIds;
+      if (!members.length) return;
+      members.forEach((memberId) => awardStudent(memberId, activeQuest));
+      const label = members.length > 1 ? `${team.name} (${members.length})` : team.name;
+      showUndoToast(activeQuest, label);
+    },
+    [activeQuest, groups, dispatch, awardStudent, showUndoToast],
   );
 
   const onKeyDown = useCallback(
@@ -132,11 +197,11 @@ export default function AwardScreen() {
           setFocus((i) => i - rowLen);
           break;
         case 'Enter':
+          e.preventDefault();
           if (activeQuest) {
-            e.preventDefault();
             const student = students[focusedIdx];
             if (student) {
-              awardSingle(student.id, activeQuest);
+              awardSingle(student.id);
             }
           }
           break;
@@ -159,40 +224,54 @@ export default function AwardScreen() {
   return (
     <div onKeyDown={onKeyDown}>
       <div style={{ position: 'sticky', top: 0, background: '#f8fafc', padding: '12px 0', zIndex: 1 }}>
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            gap: 12,
-            alignItems: 'center',
-          }}
-        >
-          <div role="radiogroup" aria-label="Aktive Quest" style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div
+            role="radiogroup"
+            aria-label="Aktive Quest"
+            style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}
+          >
             {quests.length ? (
-              quests.map((q) => (
-                <button
-                  type="button"
-                  key={q.id}
-                  role="radio"
-                  aria-checked={activeQuest?.id === q.id}
-                  onClick={() => setActiveQuestId(q.id)}
-                  style={{
-                    padding: '10px 16px',
-                    borderRadius: 999,
-                    border: activeQuest?.id === q.id ? '2px solid var(--color-primary)' : '1px solid #cbd5f5',
-                    background: activeQuest?.id === q.id ? 'rgba(91,141,239,0.12)' : '#fff',
-                    fontWeight: 600,
-                    cursor: 'pointer',
-                  }}
-                >
-                  +{q.xp} {q.name}
-                </button>
-              ))
+              quests.map((q) => {
+                const isActive = activeQuest?.id === q.id;
+                return (
+                  <button
+                    type="button"
+                    key={q.id}
+                    role="radio"
+                    aria-checked={isActive}
+                    onClick={() => setActiveQuestId(q.id)}
+                    style={{
+                      padding: '10px 16px',
+                      borderRadius: 999,
+                      border: isActive ? '2px solid var(--color-primary)' : '1px solid #cbd5f5',
+                      background: isActive ? 'rgba(91,141,239,0.12)' : '#fff',
+                      fontWeight: 600,
+                      cursor: 'pointer',
+                    }}
+                  >
+                    +{q.xp} {q.name}
+                  </button>
+                );
+              })
             ) : (
               <em>Keine aktiven Quests</em>
             )}
           </div>
-          <div style={{ display: 'flex', gap: 8, marginLeft: 'auto', flexWrap: 'wrap' }}>
+          {groups.length > 0 && (
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+              <span style={{ fontSize: 14, fontWeight: 600, color: '#475569' }}>Gruppen:</span>
+              {groups.map((team) => (
+                <GroupChip
+                  key={team.id}
+                  team={team}
+                  membersCount={team.memberIds.length}
+                  disabled={!activeQuest}
+                  onAward={awardGroup}
+                />
+              ))}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
             <button
               type="button"
               onClick={awardSelected}
@@ -223,7 +302,10 @@ export default function AwardScreen() {
             </button>
             <button
               type="button"
-              onClick={() => dispatch({ type: 'UNDO_LAST' })}
+              onClick={() => {
+                dispatch({ type: 'UNDO_LAST' });
+                clearToast();
+              }}
               aria-label="Letzte Vergabe rückgängig machen"
             >
               Undo
@@ -261,31 +343,11 @@ export default function AwardScreen() {
               xp={s.xp}
               level={s.level}
               selected={isSelected(s.id)}
-              onSelect={toggle}
-            >
-              {quests.map((q) => (
-                <button
-                  type="button"
-                  key={q.id}
-                  // Korrekte Event-Handhabung, um Bubbling zu verhindern
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    awardSingle(s.id, q);
-                  }}
-                  onMouseDown={(event) => event.stopPropagation()}
-                  style={{
-                    padding: '8px 10px',
-                    borderRadius: 999,
-                    border: '1px solid #dbe3f4',
-                    background: '#f8fbff',
-                    cursor: 'pointer',
-                  }}
-                  aria-label={`${q.name} an ${s.alias} vergeben`}
-                >
-                  +{q.xp}
-                </button>
-              ))}
-            </StudentTile>
+              disabled={!activeQuest}
+              onToggleSelect={toggle}
+              onAward={awardSingle}
+              onFocus={() => setFocusedIdx(idx)}
+            />
           </div>
         ))}
       </div>

--- a/classquest/src/ui/screens/LogScreen.tsx
+++ b/classquest/src/ui/screens/LogScreen.tsx
@@ -43,7 +43,7 @@ export default function LogScreen() {
             </option>
           ))}
         </select>
-        <select aria-label="Zeitraum" value={period} onChange={(event) => setPeriod(event.target.value as any)}>
+        <select aria-label="Zeitraum" value={period} onChange={(event) => setPeriod(event.target.value as 'today' | 'week' | 'all')}>
           <option value='today'>Heute</option>
           <option value='week'>Diese Woche</option>
           <option value='all'>Gesamt</option>


### PR DESCRIPTION
## Summary
- refactor state reducer to cover team CRUD, member sync, settings updates, and validated import handling
- redesign the awarding workflow with active quest selection, group awarding, and simplified student tiles
- add manage view tools for groups plus import/export of full app data

## Testing
- npm run build
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbec655dac832ca0143c180f4853aa