### PR TITLE
feat: add command palette and shortcuts

### DIFF
--- a/classquest/src/app/AppContext.tsx
+++ b/classquest/src/app/AppContext.tsx
@@ -22,6 +22,7 @@ type Action =
   | { type: 'TOGGLE_QUEST'; id: ID }
   | { type: 'AWARD'; payload: AwardPayload }
   | { type: 'UNDO_LAST' }
+  | { type: 'RESET_SEASON' }
   | { type: 'ADD_GROUP'; name: string }
   | { type: 'REMOVE_GROUP'; id: ID }
   | { type: 'RENAME_GROUP'; id: ID; name: string }
@@ -254,6 +255,22 @@ function reducer(state: AppState, action: Action): AppState {
         };
       });
       return { ...state, students, logs: rest };
+    }
+    case 'RESET_SEASON': {
+      const baseLevel = Math.max(1, levelFromXP(0, state.settings.xpPerLevel));
+      const students = state.students.map((student) => ({
+        ...student,
+        xp: 0,
+        level: baseLevel,
+        streaks: {},
+        lastAwardedDay: {},
+        badges: [],
+      }));
+      return {
+        ...state,
+        students,
+        logs: [],
+      };
     }
     case 'ADD_GROUP': {
       const name = action.name.trim() || `Gruppe ${state.teams.length + 1}`;

--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -5,6 +5,7 @@ export const DEFAULT_SETTINGS = {
   allowNegativeXP: false,
   sfxEnabled: false,
   compactMode: false,
+  shortcutsEnabled: true,
   onboardingCompleted: false,
   flags: { virtualize: false } as Record<string, boolean>,
 } as const;

--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -54,6 +54,7 @@ export const Settings = z.object({
   // non-breaking optional flags
   sfxEnabled: z.boolean().optional(),
   compactMode: z.boolean().optional(),
+  shortcutsEnabled: z.boolean().optional(),
   onboardingCompleted: z.boolean().optional(),
   flags: z.record(z.string(), z.boolean()).optional(),
 });
@@ -246,6 +247,7 @@ export function sanitizeState(raw: unknown): AppStateType | null {
     allowNegativeXP: asBoolean(settingsRecord.allowNegativeXP, false),
     sfxEnabled: asBoolean(settingsRecord.sfxEnabled, false),
     compactMode: asBoolean(settingsRecord.compactMode, false),
+    shortcutsEnabled: asBoolean(settingsRecord.shortcutsEnabled, true),
     onboardingCompleted: asBoolean(settingsRecord.onboardingCompleted, false),
     flags: sanitizeFlags(settingsRecord.flags),
   };

--- a/classquest/src/main.tsx
+++ b/classquest/src/main.tsx
@@ -4,12 +4,15 @@ import App from './App.tsx';
 import './index.css';
 import { AppProvider } from './app/AppContext';
 import { FeedbackProvider } from './ui/feedback/FeedbackProvider';
+import { KeyScopeProvider } from './ui/shortcut/KeyScope';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <AppProvider>
       <FeedbackProvider>
-        <App />
+        <KeyScopeProvider>
+          <App />
+        </KeyScopeProvider>
       </FeedbackProvider>
     </AppProvider>
   </React.StrictMode>,

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -28,6 +28,7 @@ export type Settings = {
   allowNegativeXP?: boolean;
   sfxEnabled?: boolean;
   compactMode?: boolean;
+  shortcutsEnabled?: boolean;
   onboardingCompleted?: boolean;
   flags?: Record<string, boolean>;
 };

--- a/classquest/src/ui/dialogs/SeasonResetDialog.tsx
+++ b/classquest/src/ui/dialogs/SeasonResetDialog.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { useHotkeyLock } from '~/ui/shortcut/KeyScope';
+
+type SeasonResetDialogProps = {
+  open: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function SeasonResetDialog({ open, onConfirm, onCancel }: SeasonResetDialogProps) {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  useHotkeyLock(open);
+
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const handle = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [open, onCancel]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const confirmButton = containerRef.current?.querySelector<HTMLButtonElement>('[data-accept]');
+    confirmButton?.focus();
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onCancel}
+      data-hotkey-suspend="true"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15, 23, 42, 0.45)',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 16,
+        zIndex: 1200,
+      }}
+    >
+      <div
+        ref={containerRef}
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          background: '#fff',
+          borderRadius: 16,
+          padding: 24,
+          width: 'min(520px, 92vw)',
+          display: 'grid',
+          gap: 16,
+          boxShadow: '0 24px 64px rgba(15, 23, 42, 0.35)',
+        }}
+      >
+        <h2 style={{ margin: 0 }}>Neue Saison starten?</h2>
+        <p style={{ margin: 0, lineHeight: 1.5 }}>
+          Dadurch werden XP, Level, Streaks und das Protokoll aller Schüler zurückgesetzt. Schüler, Gruppen und Quests
+          bleiben erhalten. Dies kann nicht rückgängig gemacht werden.
+        </p>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 12 }}>
+          <button type="button" onClick={onCancel} style={{ padding: '8px 16px', borderRadius: 10 }}>
+            Abbrechen
+          </button>
+          <button
+            type="button"
+            data-accept
+            onClick={onConfirm}
+            style={{
+              padding: '8px 18px',
+              borderRadius: 10,
+              background: '#ef4444',
+              color: '#fff',
+              border: 'none',
+              fontWeight: 600,
+            }}
+          >
+            Saison zurücksetzen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/InfoScreen.tsx
+++ b/classquest/src/ui/screens/InfoScreen.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export default function InfoScreen() {
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      <section style={{ background: '#fff', padding: 16, borderRadius: 16 }}>
+        <h2>Info &amp; Hilfe</h2>
+        <p>
+          ClassQuest unterstützt nun globale Tastaturkürzel, eine schnelle Befehls-Palette und Filter zum schnellen
+          Finden von Inhalten. Öffne die Hilfe mit <kbd>?</kbd> oder probiere <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+
+          <kbd>K</kbd>, um nach Schülern, Quests oder Aktionen zu suchen.
+        </p>
+        <p>
+          In den Einstellungen kannst du Tastaturkürzel deaktivieren. Die Befehlspalette durchsucht Navigation,
+          Aktionen, Schüler, Quests und Gruppen, so dass du blitzschnell springen kannst.
+        </p>
+      </section>
+      <section style={{ background: '#fff', padding: 16, borderRadius: 16 }}>
+        <h3>Tipps</h3>
+        <ul style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 8 }}>
+          <li>
+            <strong>Virtuelle Listen</strong> sorgen auf großen Klassenlisten für flüssige Navigation. Du findest die
+            Option unter <em>Verwalten &rarr; Einstellungen</em>.
+          </li>
+          <li>
+            Die neuen Filter über dem Leaderboard und dem Protokoll helfen dir, Namen und Ereignisse zu finden.
+            Verwende <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>F</kbd>, um sie zu fokussieren.
+          </li>
+          <li>
+            Über die Saison-Reset-Funktion kannst du XP, Level und das Protokoll für einen frischen Start zurücksetzen –
+            Schüler, Gruppen und Quests bleiben erhalten.
+          </li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/classquest/src/ui/shortcut/CommandPalette.tsx
+++ b/classquest/src/ui/shortcut/CommandPalette.tsx
@@ -1,0 +1,296 @@
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import { filterPaletteEntries } from './matcher';
+import { useHotkeyLock } from './KeyScope';
+import {
+  EVENT_EXPORT_DATA,
+  EVENT_IMPORT_DATA,
+  EVENT_FOCUS_STUDENT,
+  EVENT_SELECT_ALL,
+  EVENT_SET_ACTIVE_QUEST,
+  EVENT_TOGGLE_GROUP_FILTER,
+  EVENT_UNDO_PERFORMED,
+} from './events';
+
+type Tab = 'award' | 'leaderboard' | 'log' | 'manage' | 'info';
+
+type PaletteItem = {
+  id: string;
+  label: string;
+  group: string;
+  keywords?: string;
+  run: () => void;
+};
+
+type CommandPaletteProps = {
+  open: boolean;
+  onClose: () => void;
+  setTab: (tab: Tab) => void;
+  onOpenSeasonReset: () => void;
+};
+
+export function createPaletteItems(
+  params: {
+    setTab: (tab: Tab) => void;
+    onOpenSeasonReset: () => void;
+    dispatch: ReturnType<typeof useApp>['dispatch'];
+    state: ReturnType<typeof useApp>['state'];
+  },
+): PaletteItem[] {
+  const { state, dispatch, setTab, onOpenSeasonReset } = params;
+  const afterTab = (tab: Tab, fn: () => void) => {
+    setTab(tab);
+    window.setTimeout(fn, 20);
+  };
+
+  const navItems: PaletteItem[] = [
+    { id: 'nav-award', label: 'Gehe zu: Vergeben', group: 'Navigation', keywords: 'award', run: () => setTab('award') },
+    {
+      id: 'nav-leaderboard',
+      label: 'Gehe zu: Leaderboard',
+      group: 'Navigation',
+      keywords: 'ranking',
+      run: () => setTab('leaderboard'),
+    },
+    { id: 'nav-log', label: 'Gehe zu: Protokoll', group: 'Navigation', keywords: 'log', run: () => setTab('log') },
+    { id: 'nav-manage', label: 'Gehe zu: Verwalten', group: 'Navigation', keywords: 'manage', run: () => setTab('manage') },
+    { id: 'nav-info', label: 'Gehe zu: Info', group: 'Navigation', keywords: 'hilfe info', run: () => setTab('info') },
+  ];
+
+  const actions: PaletteItem[] = [
+    {
+      id: 'action-undo',
+      label: 'Letzte Aktion rückgängig',
+      group: 'Aktionen',
+      keywords: 'undo rückgängig u',
+      run: () => {
+        dispatch({ type: 'UNDO_LAST' });
+        window.dispatchEvent(new Event(EVENT_UNDO_PERFORMED));
+      },
+    },
+    {
+      id: 'action-export',
+      label: 'Daten exportieren',
+      group: 'Aktionen',
+      run: () => {
+        afterTab('manage', () => window.dispatchEvent(new Event(EVENT_EXPORT_DATA)));
+      },
+    },
+    {
+      id: 'action-import',
+      label: 'Daten importieren',
+      group: 'Aktionen',
+      run: () => {
+        afterTab('manage', () => window.dispatchEvent(new Event(EVENT_IMPORT_DATA)));
+      },
+    },
+    {
+      id: 'action-reset',
+      label: 'Saison zurücksetzen…',
+      group: 'Aktionen',
+      keywords: 'season reset',
+      run: () => {
+        setTab('manage');
+        onOpenSeasonReset();
+      },
+    },
+    {
+      id: 'action-select-all',
+      label: 'Alle auswählen (Vergeben)',
+      group: 'Aktionen',
+      run: () => {
+        afterTab('award', () => window.dispatchEvent(new Event(EVENT_SELECT_ALL)));
+      },
+    },
+  ];
+
+  const studentItems: PaletteItem[] = state.students.map((student) => ({
+    id: `student-${student.id}`,
+    label: `Schüler: ${student.alias}`,
+    group: 'Schüler',
+    keywords: student.alias,
+    run: () => {
+      afterTab('award', () => {
+        window.dispatchEvent(new CustomEvent(EVENT_FOCUS_STUDENT, { detail: student.id }));
+      });
+    },
+  }));
+
+  const questItems: PaletteItem[] = state.quests
+    .filter((quest) => quest.active)
+    .map((quest) => ({
+      id: `quest-${quest.id}`,
+      label: `Quest aktivieren: ${quest.name} (+${quest.xp} XP)`,
+      group: 'Quests',
+      keywords: quest.name,
+      run: () => {
+        afterTab('award', () => {
+          window.dispatchEvent(new CustomEvent(EVENT_SET_ACTIVE_QUEST, { detail: quest.id }));
+        });
+      },
+    }));
+
+  const groupItems: PaletteItem[] = state.teams.map((team) => ({
+    id: `group-${team.id}`,
+    label: `Gruppe filtern: ${team.name}`,
+    group: 'Gruppen',
+    keywords: team.name,
+    run: () => {
+      afterTab('award', () => {
+        window.dispatchEvent(new CustomEvent(EVENT_TOGGLE_GROUP_FILTER, { detail: team.id }));
+      });
+    },
+  }));
+
+  return [...navItems, ...actions, ...studentItems, ...questItems, ...groupItems];
+}
+
+export default function CommandPalette({ open, onClose, setTab, onOpenSeasonReset }: CommandPaletteProps) {
+  const { state, dispatch } = useApp();
+  const [query, setQuery] = React.useState('');
+  const [activeIndex, setActiveIndex] = React.useState(0);
+  const items = React.useMemo(
+    () => createPaletteItems({ state, dispatch, setTab, onOpenSeasonReset }),
+    [state, dispatch, setTab, onOpenSeasonReset],
+  );
+  const filtered = React.useMemo(() => filterPaletteEntries(items, query), [items, query]);
+
+  useHotkeyLock(open);
+
+  React.useEffect(() => {
+    if (open) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  React.useEffect(() => {
+    if (activeIndex >= filtered.length) {
+      setActiveIndex(filtered.length > 0 ? filtered.length - 1 : 0);
+    }
+  }, [filtered, activeIndex]);
+
+  const runItem = React.useCallback(
+    (item: PaletteItem | undefined) => {
+      if (!item) return;
+      item.run();
+      onClose();
+    },
+    [onClose],
+  );
+
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setActiveIndex((prev) => Math.min(prev + 1, Math.max(0, filtered.length - 1)));
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setActiveIndex((prev) => Math.max(0, prev - 1));
+        return;
+      }
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        runItem(filtered[activeIndex]);
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    },
+    [filtered, activeIndex, onClose, runItem],
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      data-hotkey-suspend="true"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15, 23, 42, 0.4)',
+        display: 'grid',
+        placeItems: 'start center',
+        paddingTop: '10vh',
+        zIndex: 1100,
+      }}
+    >
+      <div
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          width: 'min(720px, 92vw)',
+          background: '#fff',
+          borderRadius: 16,
+          boxShadow: '0 20px 60px rgba(15, 23, 42, 0.35)',
+          padding: 16,
+          display: 'grid',
+          gap: 12,
+        }}
+      >
+        <input
+          autoFocus
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={onKeyDown}
+          placeholder="Befehl oder Name suchen…"
+          aria-label="Befehl suchen"
+          style={{
+            width: '100%',
+            padding: '12px 14px',
+            borderRadius: 12,
+            border: '1px solid #cbd5f5',
+            fontSize: 16,
+          }}
+        />
+        <div
+          role="listbox"
+          aria-label="Suchergebnisse"
+          style={{ maxHeight: '50vh', overflowY: 'auto', display: 'grid', gap: 4 }}
+        >
+          {filtered.length === 0 && <div style={{ padding: '12px 14px', opacity: 0.6 }}>Keine Treffer</div>}
+          {filtered.map((item, index) => {
+            const isActive = index === activeIndex;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onClick={() => runItem(item)}
+                onMouseEnter={() => setActiveIndex(index)}
+                style={{
+                  textAlign: 'left',
+                  border: 'none',
+                  background: isActive ? 'rgba(59, 130, 246, 0.12)' : 'transparent',
+                  borderRadius: 12,
+                  padding: '10px 12px',
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  alignItems: 'center',
+                  cursor: 'pointer',
+                  fontSize: 15,
+                }}
+              >
+                <span>{item.label}</span>
+                <span style={{ fontSize: 12, textTransform: 'uppercase', opacity: 0.6 }}>{item.group}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/classquest/src/ui/shortcut/HelpOverlay.tsx
+++ b/classquest/src/ui/shortcut/HelpOverlay.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { useHotkeyLock } from './KeyScope';
+
+type HelpOverlayProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+const SHORTCUTS: Array<{ combo: string; description: string }> = [
+  { combo: '?', description: 'Hilfe anzeigen' },
+  { combo: '⌘/Ctrl + K', description: 'Befehlspalette öffnen' },
+  { combo: 'U oder ⌘/Ctrl + Z', description: 'Letzte Aktion rückgängig' },
+  { combo: 'A', description: 'Alle Schüler auswählen (Vergeben)' },
+  { combo: 'Esc', description: 'Auswahl leeren / Dialog schließen' },
+  { combo: '1–5', description: 'Zwischen den Tabs wechseln' },
+  { combo: 'Pfeiltasten', description: 'Schülerkacheln navigieren' },
+  { combo: 'Enter', description: 'Aktive Quest vergeben' },
+  { combo: '⌘/Ctrl + F', description: 'Filter im Leaderboard/Protokoll fokussieren' },
+];
+
+export default function HelpOverlay({ open, onClose }: HelpOverlayProps) {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  useHotkeyLock(open);
+
+  React.useEffect(() => {
+    if (!open) return undefined;
+    const handle = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [open, onClose]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const button = containerRef.current?.querySelector<HTMLButtonElement>('button');
+    button?.focus();
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      data-hotkey-suspend="true"
+      onClick={onClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15, 23, 42, 0.45)',
+        display: 'grid',
+        placeItems: 'center',
+        padding: 16,
+        zIndex: 1100,
+      }}
+    >
+      <div
+        ref={containerRef}
+        onClick={(event) => event.stopPropagation()}
+        style={{
+          background: '#fff',
+          color: '#0f172a',
+          borderRadius: 16,
+          padding: 20,
+          width: 'min(720px, 94vw)',
+          boxShadow: '0 24px 64px rgba(15, 23, 42, 0.35)',
+          display: 'grid',
+          gap: 16,
+        }}
+      >
+        <header style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <h2 style={{ margin: 0, fontSize: 22 }}>Tastaturkürzel</h2>
+          <span style={{ fontSize: 12, opacity: 0.7 }}>Schneller arbeiten mit ClassQuest</span>
+        </header>
+        <div style={{ display: 'grid', gap: 8 }}>
+          {SHORTCUTS.map((shortcut) => (
+            <div
+              key={shortcut.combo}
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                padding: '6px 10px',
+                borderRadius: 10,
+                background: 'rgba(226, 232, 240, 0.6)',
+              }}
+            >
+              <strong style={{ fontFamily: 'monospace', letterSpacing: 0.5 }}>{shortcut.combo}</strong>
+              <span style={{ fontSize: 14 }}>{shortcut.description}</span>
+            </div>
+          ))}
+        </div>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+          <button type="button" onClick={onClose} style={{ padding: '8px 14px', borderRadius: 10 }}>
+            Schließen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/classquest/src/ui/shortcut/KeyScope.tsx
+++ b/classquest/src/ui/shortcut/KeyScope.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import { shouldIgnoreHotkey } from './guards';
+
+type Handler = (event: KeyboardEvent) => void;
+
+type KeyScopeValue = {
+  register: (handler: Handler) => () => void;
+  suspend: () => () => void;
+};
+
+export const KeyScopeContext = React.createContext<KeyScopeValue | null>(null);
+
+export function KeyScopeProvider({ children }: { children: React.ReactNode }) {
+  const { state } = useApp();
+  const handlersRef = React.useRef(new Set<Handler>());
+  const suspendCountRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (state.settings.shortcutsEnabled === false) {
+      return;
+    }
+
+    const handle = (event: KeyboardEvent) => {
+      if (suspendCountRef.current > 0) {
+        return;
+      }
+      if (shouldIgnoreHotkey(event)) {
+        return;
+      }
+      handlersRef.current.forEach((handler) => handler(event));
+    };
+
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [state.settings.shortcutsEnabled]);
+
+  const register = React.useCallback((handler: Handler) => {
+    handlersRef.current.add(handler);
+    return () => {
+      handlersRef.current.delete(handler);
+    };
+  }, []);
+
+  const suspend = React.useCallback(() => {
+    suspendCountRef.current += 1;
+    return () => {
+      suspendCountRef.current = Math.max(0, suspendCountRef.current - 1);
+    };
+  }, []);
+
+  const value = React.useMemo<KeyScopeValue>(() => ({ register, suspend }), [register, suspend]);
+
+  return <KeyScopeContext.Provider value={value}>{children}</KeyScopeContext.Provider>;
+}
+
+export function useKeydown(handler: Handler) {
+  const context = React.useContext(KeyScopeContext);
+  React.useEffect(() => {
+    if (!context) return;
+    return context.register(handler);
+  }, [context, handler]);
+}
+
+export function useHotkeyLock(active: boolean) {
+  const context = React.useContext(KeyScopeContext);
+  React.useEffect(() => {
+    if (!context || !active) {
+      return undefined;
+    }
+    return context.suspend();
+  }, [context, active]);
+}

--- a/classquest/src/ui/shortcut/events.ts
+++ b/classquest/src/ui/shortcut/events.ts
@@ -1,0 +1,10 @@
+export const EVENT_SELECT_ALL = 'cq:select-all-students';
+export const EVENT_CLEAR_SELECTION = 'cq:clear-selection';
+export const EVENT_FOCUS_STUDENT = 'cq:focus-student';
+export const EVENT_SET_ACTIVE_QUEST = 'cq:set-active-quest';
+export const EVENT_TOGGLE_GROUP_FILTER = 'cq:toggle-group-filter';
+export const EVENT_UNDO_PERFORMED = 'cq:undo-performed';
+export const EVENT_REQUEST_UNDO = 'cq:request-undo';
+export const EVENT_EXPORT_DATA = 'cq:export-data';
+export const EVENT_IMPORT_DATA = 'cq:import-data';
+export const EVENT_OPEN_SEASON_RESET = 'cq:open-season-reset';

--- a/classquest/src/ui/shortcut/guards.ts
+++ b/classquest/src/ui/shortcut/guards.ts
@@ -1,0 +1,41 @@
+const PASSIVE_INPUT_TYPES = new Set(['button', 'checkbox', 'radio', 'reset', 'submit', 'range', 'color', 'file', 'image']);
+
+export function isEditableTarget(element: HTMLElement | null): boolean {
+  if (!element) {
+    return false;
+  }
+  if (element.closest('[data-hotkey-suspend="true"]')) {
+    return true;
+  }
+  if (element.isContentEditable) {
+    return true;
+  }
+  const role = element.getAttribute('role');
+  if (role === 'textbox') {
+    return true;
+  }
+  const tag = element.tagName.toLowerCase();
+  if (tag === 'textarea' || tag === 'select') {
+    return true;
+  }
+  if (tag === 'input') {
+    const input = element as HTMLInputElement;
+    const type = input.type?.toLowerCase() || 'text';
+    if (PASSIVE_INPUT_TYPES.has(type)) {
+      return false;
+    }
+    if (input.readOnly) {
+      return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+export function shouldIgnoreHotkey(event: KeyboardEvent): boolean {
+  if (event.defaultPrevented) {
+    return true;
+  }
+  const target = event.target as HTMLElement | null;
+  return isEditableTarget(target);
+}

--- a/classquest/src/ui/shortcut/matcher.ts
+++ b/classquest/src/ui/shortcut/matcher.ts
@@ -1,0 +1,18 @@
+export type PaletteEntry = { label: string; keywords?: string };
+
+export function filterPaletteEntries<T extends PaletteEntry>(items: T[], query: string): T[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return items;
+  }
+  return items.filter((item) => {
+    const haystack = item.label.toLowerCase();
+    if (haystack.includes(normalized)) {
+      return true;
+    }
+    if (item.keywords) {
+      return item.keywords.toLowerCase().includes(normalized);
+    }
+    return false;
+  });
+}

--- a/classquest/tests-e2e/core-flows.spec.ts
+++ b/classquest/tests-e2e/core-flows.spec.ts
@@ -31,7 +31,21 @@ test.describe('Core flows', () => {
     await page.getByRole('radio').first().click();
     await page.getByRole('button', { name: /lena/i }).click();
 
-    await page.getByRole('button', { name: selectors.undoButton }).click();
+    const undoToast = page.getByText(/drücke u/i);
+    await expect(undoToast).toBeVisible();
+    await page.keyboard.press('KeyU');
+    await expect(undoToast).toBeHidden({ timeout: 2000 });
+
+    const paletteShortcut = process.platform === 'darwin' ? 'Meta+K' : 'Control+K';
+    await page.keyboard.press(paletteShortcut);
+    const paletteDialog = page.getByRole('dialog');
+    await expect(paletteDialog).toBeVisible();
+    await paletteDialog.getByRole('textbox', { name: /befehl suchen/i }).fill('Verwalten');
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('heading', { name: /schüler verwalten/i })).toBeVisible();
+
+    await page.keyboard.press('Digit1');
+    await expect(page.getByRole('tab', { name: selectors.awardTab })).toHaveAttribute('aria-selected', 'true');
 
     await page.getByRole('tab', { name: selectors.manageTab }).click();
     const [download] = await Promise.all([

--- a/classquest/tests/palette.test.ts
+++ b/classquest/tests/palette.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { filterPaletteEntries } from '~/ui/shortcut/matcher';
+import { shouldIgnoreHotkey } from '~/ui/shortcut/guards';
+
+describe('filterPaletteEntries', () => {
+  it('matches substrings without case sensitivity', () => {
+    const items = [
+      { label: 'Hausaufgabe' },
+      { label: 'Feedback geben' },
+      { label: 'Quiz' },
+    ];
+    const result = filterPaletteEntries(items, 'auf');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.label).toBe('Hausaufgabe');
+  });
+
+  it('returns all entries when query is empty', () => {
+    const items = [{ label: 'A' }, { label: 'B' }];
+    const result = filterPaletteEntries(items, '');
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('shouldIgnoreHotkey', () => {
+  const baseTarget = {
+    closest: () => null,
+    isContentEditable: false,
+    getAttribute: () => null,
+  } as unknown as HTMLElement;
+
+  it('ignores key presses inside text inputs', () => {
+    const inputTarget = {
+      ...baseTarget,
+      tagName: 'INPUT',
+      type: 'text',
+      readOnly: false,
+    } as unknown as HTMLInputElement;
+    const event = { target: inputTarget, defaultPrevented: false } as KeyboardEvent;
+    expect(shouldIgnoreHotkey(event)).toBe(true);
+  });
+
+  it('handles contentEditable elements', () => {
+    const editableTarget = {
+      ...baseTarget,
+      tagName: 'DIV',
+      isContentEditable: true,
+    } as unknown as HTMLElement;
+    const event = { target: editableTarget, defaultPrevented: false } as KeyboardEvent;
+    expect(shouldIgnoreHotkey(event)).toBe(true);
+  });
+
+  it('allows shortcuts on regular buttons', () => {
+    const buttonTarget = {
+      ...baseTarget,
+      tagName: 'BUTTON',
+    } as unknown as HTMLElement;
+    const event = { target: buttonTarget, defaultPrevented: false } as KeyboardEvent;
+    expect(shouldIgnoreHotkey(event)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a global shortcut provider with toggleable settings and new help/season reset dialogs
- add a command palette with fuzzy search to navigate tabs, run actions, and focus students/groups/quests
- expose inline filters and shortcut focus for leaderboard/log plus add an info screen and shortcut tests

## Testing
- npm run build
- npm run test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68cd4c2f21ac832ca988fc6ad30fa0b2