### PR TITLE
Add star icon and avatar upload workflows

### DIFF
--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -10,4 +10,5 @@ export const DEFAULT_SETTINGS = {
   shortcutsEnabled: true,
   onboardingCompleted: false,
   flags: { virtualize: false } as Record<string, boolean>,
+  classStarIconKey: null,
 } as const;

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -102,6 +102,8 @@ export const addStudent = (state: AppState, input: StudentInput): AppState => {
     lastAwardedDay: {},
     badges: [],
     teamId: targetTeam?.id,
+    avatarMode: 'procedural',
+    avatarPack: { stageKeys: [null, null, null] },
   };
 
   const teams = targetTeam

--- a/classquest/src/services/blobStore/index.ts
+++ b/classquest/src/services/blobStore/index.ts
@@ -1,0 +1,1 @@
+export { putBlob, getBlob, deleteBlob, getObjectURL, clearObjectURL } from './indexedDb';

--- a/classquest/src/services/blobStore/indexedDb.test.ts
+++ b/classquest/src/services/blobStore/indexedDb.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteBlob, getBlob, getObjectURL, putBlob } from './indexedDb';
+
+describe('indexedDb blob store', () => {
+  const originalCreate = URL.createObjectURL;
+  const originalRevoke = URL.revokeObjectURL;
+  let counter = 0;
+  const revokeMock = vi.fn();
+
+  beforeEach(() => {
+    counter = 0;
+    (URL.createObjectURL as unknown as (blob: Blob) => string) = () => `blob:test-${counter++}`;
+    (URL.revokeObjectURL as unknown as (url: string) => void) = revokeMock;
+    revokeMock.mockReset();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = originalCreate;
+    URL.revokeObjectURL = originalRevoke;
+  });
+
+  it('stores, reads and deletes blobs', async () => {
+    const blob = new Blob(['hello'], { type: 'image/png' });
+    const id = await putBlob(blob);
+    expect(typeof id).toBe('string');
+
+    const stored = await getBlob(id);
+    expect(stored).not.toBeNull();
+    expect(await stored!.text()).toBe('hello');
+
+    const url = await getObjectURL(id);
+    expect(url).toBe('blob:test-0');
+    const cachedAgain = await getObjectURL(id);
+    expect(cachedAgain).toBe(url);
+
+    await deleteBlob(id);
+    expect(await getBlob(id)).toBeNull();
+    expect(await getObjectURL(id)).toBeNull();
+    expect(revokeMock).toHaveBeenCalledWith(url);
+  });
+});

--- a/classquest/src/services/blobStore/indexedDb.ts
+++ b/classquest/src/services/blobStore/indexedDb.ts
@@ -1,0 +1,220 @@
+const DB_NAME = 'classquest-blobs';
+const STORE_NAME = 'images';
+
+const memoryStore = new Map<string, Blob>();
+const urlCache = new Map<string, string>();
+
+let useMemoryStore = false;
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+const createId = () =>
+  globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+
+function ensureMemoryStore() {
+  useMemoryStore = true;
+  return memoryStore;
+}
+
+async function getDatabase(): Promise<IDBDatabase | null> {
+  if (useMemoryStore) {
+    return null;
+  }
+
+  if (typeof indexedDB === 'undefined' || indexedDB === null) {
+    ensureMemoryStore();
+    return null;
+  }
+
+  if (!dbPromise) {
+    dbPromise = new Promise<IDBDatabase | null>((resolve) => {
+      try {
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains(STORE_NAME)) {
+            db.createObjectStore(STORE_NAME);
+          }
+        };
+        request.onsuccess = () => {
+          const db = request.result;
+          db.onclose = () => {
+            // When the database closes unexpectedly we fall back to the memory store to stay functional.
+            ensureMemoryStore();
+          };
+          resolve(db);
+        };
+        request.onerror = () => {
+          console.warn('IndexedDB (blob store) unavailable, falling back to memory store.', request.error);
+          resolve(null);
+        };
+        request.onblocked = () => {
+          console.warn('IndexedDB (blob store) open blocked, using memory store as fallback.');
+          resolve(null);
+        };
+      } catch (error) {
+        console.warn('IndexedDB (blob store) init failed, using memory store.', error);
+        resolve(null);
+      }
+    }).then((db) => {
+      if (!db) {
+        ensureMemoryStore();
+      }
+      return db;
+    });
+  }
+
+  const db = await dbPromise;
+  if (!db) {
+    ensureMemoryStore();
+  }
+  return db;
+}
+
+function runTransaction(
+  db: IDBDatabase,
+  mode: IDBTransactionMode,
+  executor: (store: IDBObjectStore) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, mode);
+    const store = transaction.objectStore(STORE_NAME);
+    try {
+      executor(store);
+    } catch (error) {
+      reject(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+    transaction.onerror = () => reject(transaction.error ?? new Error('IndexedDB transaction failed'));
+  });
+}
+
+function cacheUrl(id: string, blob: Blob) {
+  const existing = urlCache.get(id);
+  if (existing) {
+    try {
+      URL.revokeObjectURL(existing);
+    } catch (error) {
+      console.warn('Failed to revoke object URL', error);
+    }
+  }
+  try {
+    const url = URL.createObjectURL(blob);
+    urlCache.set(id, url);
+  } catch (error) {
+    console.warn('Unable to create object URL', error);
+  }
+}
+
+function revokeCachedUrl(id: string) {
+  const url = urlCache.get(id);
+  if (!url) return;
+  try {
+    URL.revokeObjectURL(url);
+  } catch (error) {
+    console.warn('Failed to revoke object URL', error);
+  }
+  urlCache.delete(id);
+}
+
+export async function putBlob(file: Blob): Promise<string> {
+  const id = createId();
+  const db = await getDatabase();
+
+  if (db) {
+    try {
+      await runTransaction(db, 'readwrite', (store) => {
+        store.put(file, id);
+      });
+    } catch (error) {
+      console.warn('IndexedDB put failed, switching to memory store.', error);
+      ensureMemoryStore();
+      memoryStore.set(id, file);
+    }
+  } else {
+    memoryStore.set(id, file);
+  }
+
+  cacheUrl(id, file);
+  return id;
+}
+
+export async function getBlob(id: string): Promise<Blob | null> {
+  if (!id) return null;
+
+  if (useMemoryStore) {
+    return memoryStore.get(id) ?? null;
+  }
+
+  const db = await getDatabase();
+  if (!db) {
+    return memoryStore.get(id) ?? null;
+  }
+
+  return await new Promise<Blob | null>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.get(id);
+    request.onsuccess = () => {
+      const value = request.result;
+      resolve(value instanceof Blob ? value : null);
+    };
+    request.onerror = () => {
+      reject(request.error ?? new Error('IndexedDB get failed'));
+    };
+    transaction.onabort = () => {
+      reject(transaction.error ?? new Error('IndexedDB transaction aborted'));
+    };
+  }).catch((error) => {
+    console.warn('IndexedDB get failed, attempting memory store fallback.', error);
+    ensureMemoryStore();
+    return memoryStore.get(id) ?? null;
+  });
+}
+
+export async function deleteBlob(id: string): Promise<void> {
+  if (!id) return;
+
+  let deletedFromDb = false;
+  const db = await getDatabase();
+  if (db) {
+    try {
+      await runTransaction(db, 'readwrite', (store) => {
+        store.delete(id);
+      });
+      deletedFromDb = true;
+    } catch (error) {
+      console.warn('IndexedDB delete failed, using memory store fallback.', error);
+      ensureMemoryStore();
+    }
+  }
+
+  if (!deletedFromDb || useMemoryStore) {
+    memoryStore.delete(id);
+  }
+
+  revokeCachedUrl(id);
+}
+
+export async function getObjectURL(id: string): Promise<string | null> {
+  if (!id) return null;
+  const cached = urlCache.get(id);
+  if (cached) return cached;
+
+  const blob = await getBlob(id);
+  if (!blob) return null;
+
+  try {
+    const url = URL.createObjectURL(blob);
+    urlCache.set(id, url);
+    return url;
+  } catch (error) {
+    console.warn('Unable to create object URL', error);
+    return null;
+  }
+}
+
+export function clearObjectURL(id: string) {
+  revokeCachedUrl(id);
+}

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,11 +1,18 @@
 export type ID = string;
 export type Badge = { id: ID; name: string; icon?: string; description?: string };
 
+export type StudentAvatarMode = 'procedural' | 'imagePack';
+export type StudentAvatarPack = {
+  stageKeys: (string | null)[];
+};
+
 export type Student = {
   id: ID; alias: string; xp: number; level: number;
   streaks: Record<ID, number>;
   lastAwardedDay: Record<ID, string>; // YYYY-MM-DD
   badges: Badge[]; teamId?: ID;
+  avatarMode?: StudentAvatarMode;
+  avatarPack?: StudentAvatarPack;
 };
 
 export type Team = { id: ID; name: string; memberIds: ID[] };
@@ -33,6 +40,7 @@ export type Settings = {
   animationsEnabled?: boolean;
   kidModeEnabled?: boolean;
   flags?: Record<string, boolean>;
+  classStarIconKey?: string | null;
 };
 
 export type AppState = {

--- a/classquest/tests-e2e/uploads.spec.ts
+++ b/classquest/tests-e2e/uploads.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function openManageTab(page: Page) {
+  await page.goto('/');
+  const nameInput = page.getByLabel(/Klassenname|Class name/i);
+  if (await nameInput.isVisible()) {
+    await nameInput.fill('Testklasse');
+    await page.getByRole('button', { name: /weiter|continue/i }).click();
+  }
+  await page.getByRole('tab', { name: /verwalten|manage/i }).click();
+}
+
+test.describe('Image uploads', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.localStorage.clear();
+      try {
+        const request = indexedDB.deleteDatabase('classquest-blobs');
+        request.onerror = () => undefined;
+      } catch (error) {
+        // ignore
+      }
+    });
+  });
+
+  test('class star icon upload and removal', async ({ page }) => {
+    await openManageTab(page);
+
+    const chooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Stern-Icon wählen' }).click();
+    const chooser = await chooserPromise;
+    const pngData = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/lIadAAAAAElFTkSuQmCC',
+      'base64',
+    );
+    await chooser.setFiles({ name: 'star.png', mimeType: 'image/png', buffer: pngData });
+
+    await expect(page.getByAltText('Stern-Icon Vorschau')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Stern-Icon entfernen' }).click();
+    await expect(page.getByAltText('Stern-Icon Vorschau')).toHaveCount(0);
+  });
+
+  test('student avatar upload for stage 0', async ({ page }) => {
+    await openManageTab(page);
+
+    await page.getByPlaceholder(/^Alias$/i).fill('Lena');
+    await page.getByRole('button', { name: /hinzufügen|add/i }).click();
+
+    await page.getByRole('radio', { name: 'Bildpaket' }).first().check();
+
+    const chooserPromise = page.waitForEvent('filechooser');
+    await page.getByRole('button', { name: 'Avatar Stufe 0 wählen' }).click();
+    const chooser = await chooserPromise;
+    const pngData = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/lIadAAAAAElFTkSuQmCC',
+      'base64',
+    );
+    await chooser.setFiles({ name: 'avatar.png', mimeType: 'image/png', buffer: pngData });
+
+    await expect(page.getByAltText('Avatar-Stufe 0 Vorschau für Lena')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add an IndexedDB-backed blob store with object URL caching and a memory fallback for image assets
- extend core types, schemas, and defaults to persist star icon selections and per-student avatar packs
- enhance the manage screen with star icon upload controls, avatar pack slots, and drag-and-drop interactions
- cover the new flows with blob store unit tests and Playwright scenarios for star icon and avatar uploads

## Testing
- npm run build
- npm run test
- npx playwright test

------
https://chatgpt.com/codex/tasks/task_e_68ce7e330af4832ca208cd22219821a9