### PR TITLE
Fix ManageScreen category helper naming

### DIFF
--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -20,6 +20,7 @@ const createState = (studentOverrides: Partial<Student> = {}): AppState => {
     students: [student],
     teams: [],
     quests: [],
+    categories: [],
     logs: [],
     settings: {
       className: 'Demo',

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -36,6 +36,7 @@ const sampleState = (): AppState => ({
   students: [{ id: 's1', alias: 'Lena', xp: 10, level: 1, streaks: {}, lastAwardedDay: {}, badges: [] }],
   teams: [],
   quests: [{ id: 'q1', name: 'Hausaufgaben', xp: 10, type: 'daily', target: 'individual', active: true }],
+  categories: [],
   logs: [],
   settings: { className: '4a', xpPerLevel: 100, streakThresholdForBadge: 5, allowNegativeXP: false },
   version: 1,


### PR DESCRIPTION
## Summary
- rename the first ManageScreen category helper to avoid redeclaration with the later category logic
- hoist usedCategoryIds so the memo is defined before it is referenced
- add categories to test AppState fixtures now that the field is required

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfd531076c832c8190cdd20ef9d707