### PR TITLE
Add profile card to student detail modal

### DIFF
--- a/classquest/src/ui/components/ProfileCard.tsx
+++ b/classquest/src/ui/components/ProfileCard.tsx
@@ -1,0 +1,222 @@
+import { useMemo } from 'react';
+import { useApp } from '~/app/AppContext';
+import { selectStudentById } from '~/core/selectors/student';
+import { AvatarView } from '~/ui/avatar/AvatarView';
+import { BadgeIcon } from '~/ui/components/BadgeIcon';
+import type { Badge } from '~/types/models';
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+
+const formatNumber = (value: number) => numberFormatter.format(Math.max(0, Math.round(value)));
+
+const MAX_BADGES_DISPLAYED = 16;
+
+const sortBadgesByAwardedAt = (badges: Badge[]): Badge[] => {
+  const copy = [...badges];
+  copy.sort((a, b) => {
+    const timeA = Date.parse(a.awardedAt);
+    const timeB = Date.parse(b.awardedAt);
+    if (Number.isNaN(timeA) && Number.isNaN(timeB)) return 0;
+    if (Number.isNaN(timeA)) return 1;
+    if (Number.isNaN(timeB)) return -1;
+    return timeB - timeA;
+  });
+  return copy;
+};
+
+type ProfileCardProps = {
+  studentId: string;
+  titleId?: string;
+};
+
+export function ProfileCard({ studentId, titleId }: ProfileCardProps) {
+  const { state } = useApp();
+
+  const student = useMemo(
+    () => selectStudentById({ students: state.students }, studentId),
+    [state.students, studentId],
+  );
+
+  const classMaxXp = useMemo(() => {
+    let max = 0;
+    for (const entry of state.students) {
+      const xp = entry?.xp ?? 0;
+      if (xp > max) {
+        max = xp;
+      }
+    }
+    return Math.max(1, max);
+  }, [state.students]);
+
+  if (!student) {
+    return null;
+  }
+
+  const xpPerLevelSetting = state.settings?.xpPerLevel ?? 100;
+  const xpPerLevel = Math.max(1, Math.round(xpPerLevelSetting));
+  const level = Math.max(1, Math.round(student.level ?? 1));
+  const xpTotal = Math.max(0, Math.round(student.xp ?? 0));
+  const baseXpForLevel = (level - 1) * xpPerLevel;
+  const rawInLevel = xpTotal - baseXpForLevel;
+  const inLevel = Math.max(0, Math.min(xpPerLevel, rawInLevel));
+  const ratio = classMaxXp > 0 ? Math.min(1, xpTotal / classMaxXp) : 0;
+
+  const badges = Array.isArray(student.badges) ? student.badges : [];
+  const recentBadges = sortBadgesByAwardedAt(badges).slice(0, MAX_BADGES_DISPLAYED);
+
+  return (
+    <article
+      aria-label="Profilkarte"
+      style={{
+        margin: '0 auto',
+        width: '100%',
+        maxWidth: 420,
+        display: 'grid',
+        gap: 24,
+        padding: 24,
+        borderRadius: 28,
+        border: '1px solid rgba(15,23,42,0.08)',
+        background: 'linear-gradient(180deg, #ffffff, #f8fafc)',
+        boxShadow: '0 36px 64px rgba(15,23,42,0.15)',
+      }}
+    >
+      <div
+        style={{
+          position: 'relative',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 12,
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 12,
+            borderRadius: 999,
+            background: 'radial-gradient(45% 45% at 50% 50%, rgba(255,107,53,0.28), transparent 70%)',
+            filter: 'blur(40px)',
+            opacity: 0.8,
+          }}
+        />
+        <AvatarView
+          student={{
+            alias: student.alias,
+            avatarMode: student.avatarMode,
+            avatarPack: student.avatarPack,
+            level: student.level,
+            xp: student.xp,
+          }}
+          size={200}
+          rounded="xl"
+          style={{ boxShadow: '0 18px 32px rgba(15,23,42,0.25)' }}
+        />
+      </div>
+
+      <div style={{ textAlign: 'center', display: 'grid', gap: 8 }}>
+        <h2
+          id={titleId}
+          style={{
+            margin: 0,
+            fontSize: 28,
+            fontWeight: 800,
+            color: '#0f172a',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          {student.alias}
+        </h2>
+        <div
+          style={{
+            textTransform: 'uppercase',
+            letterSpacing: '0.2em',
+            fontSize: 12,
+            fontWeight: 600,
+            color: '#64748b',
+          }}
+        >
+          Level
+        </div>
+        <div style={{ fontSize: 46, fontWeight: 900, color: '#0f172a' }}>{formatNumber(level)}</div>
+        <div style={{ fontSize: 13, color: '#475569' }}>
+          {formatNumber(inLevel)} / {formatNumber(xpPerLevel)} XP in diesem Level
+        </div>
+      </div>
+
+      <section style={{ display: 'grid', gap: 12 }}>
+        <h3 style={{ margin: 0, textAlign: 'center', fontSize: 16, fontWeight: 700, color: '#0f172a' }}>Badges</h3>
+        {recentBadges.length === 0 ? (
+          <p style={{ margin: 0, textAlign: 'center', fontSize: 14, color: '#64748b' }}>
+            Noch keine Badges vergeben.
+          </p>
+        ) : (
+          <ul
+            style={{
+              listStyle: 'none',
+              margin: 0,
+              padding: 0,
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'center',
+              gap: 10,
+              maxHeight: 120,
+              overflowY: 'auto',
+            }}
+          >
+            {recentBadges.map((badge) => (
+              <li
+                key={`${badge.id}-${badge.awardedAt}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '6px 12px',
+                  borderRadius: 999,
+                  border: '1px solid rgba(15,23,42,0.12)',
+                  background: 'rgba(148,163,184,0.12)',
+                  backdropFilter: 'blur(10px)',
+                }}
+              >
+                <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={36} />
+                <span style={{ fontSize: 13, fontWeight: 600, color: '#0f172a' }}>{badge.name}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section style={{ display: 'grid', gap: 10 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 14, color: '#475569' }}>
+          <span>Gesamt-XP</span>
+          <strong style={{ fontSize: 15, color: '#0f172a' }}>{formatNumber(xpTotal)} XP</strong>
+        </div>
+        <div
+          aria-hidden
+          style={{
+            width: '100%',
+            height: 12,
+            borderRadius: 999,
+            background: 'rgba(148,163,184,0.25)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: `${Math.round(ratio * 100)}%`,
+              height: '100%',
+              borderRadius: 999,
+              background: 'linear-gradient(90deg, #34d399, #38bdf8)',
+              transition: 'width 0.2s ease',
+            }}
+          />
+        </div>
+        <div style={{ fontSize: 12, color: '#64748b', textAlign: 'right' }}>
+          Klassenbestwert: {formatNumber(classMaxXp)} XP
+        </div>
+      </section>
+    </article>
+  );
+}
+
+export default ProfileCard;

--- a/classquest/src/ui/screens/StudentDetailScreen.tsx
+++ b/classquest/src/ui/screens/StudentDetailScreen.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import type { LogEntry, Student } from '~/types/models';
-import { AvatarView } from '~/ui/avatar/AvatarView';
-import { BadgeIcon } from '~/ui/components/BadgeIcon';
+import ProfileCard from '~/ui/components/ProfileCard';
 
 type StudentDetailScreenProps = {
   student: Pick<Student, 'id' | 'alias' | 'xp' | 'level' | 'badges' | 'avatarMode' | 'avatarPack'>;
@@ -51,100 +50,70 @@ export default function StudentDetailScreen({ student, logs, onClose }: StudentD
         role="document"
         onClick={(event) => event.stopPropagation()}
         style={{
-          background: '#fff',
-          borderRadius: 20,
-          maxWidth: 520,
+          background: 'transparent',
+          borderRadius: 24,
+          maxWidth: 560,
           width: '100%',
           maxHeight: '90vh',
           overflowY: 'auto',
-          boxShadow: '0 24px 48px rgba(15,23,42,0.25)',
         }}
       >
-        <div style={{ display: 'flex', justifyContent: 'flex-end', padding: 16 }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', padding: 8 }}>
           <button
             type="button"
             onClick={onClose}
             aria-label="Detailansicht schließen"
             style={{
               border: 'none',
-              background: 'transparent',
-              fontSize: 18,
+              background: 'rgba(15,23,42,0.06)',
+              color: '#0f172a',
+              borderRadius: 999,
+              width: 36,
+              height: 36,
+              fontSize: 20,
               cursor: 'pointer',
+              lineHeight: 1,
             }}
           >
             ×
           </button>
         </div>
         <div style={{ padding: '0 24px 24px', display: 'grid', gap: 24 }}>
-          <header style={{ display: 'flex', alignItems: 'center', gap: 20 }}>
-            <AvatarView
-              student={{
-                alias: student.alias,
-                avatarMode: student.avatarMode,
-                avatarPack: student.avatarPack,
-                level: student.level,
-                xp: student.xp,
-              }}
-              size={96}
-              rounded="xl"
-            />
-            <div>
-              <h2 id="student-detail-title" style={{ margin: 0, fontSize: 24 }}>{student.alias}</h2>
-              <p style={{ margin: '4px 0 0', color: '#475569' }}>
-                {student.xp} XP · Level {student.level}
-              </p>
-            </div>
-          </header>
+          <ProfileCard studentId={student.id} titleId="student-detail-title" />
 
-          {student.badges?.length ? (
-            <section>
-              <h3 style={{ margin: '0 0 12px', fontSize: 18 }}>Badges</h3>
-              <ul style={{ display: 'flex', flexWrap: 'wrap', gap: 8, margin: 0, padding: 0, listStyle: 'none' }}>
-                {student.badges.map((badge) => (
-                  <li
-                    key={`${badge.id}-${badge.awardedAt}`}
-                    style={{
-                      padding: '6px 12px',
-                      borderRadius: 999,
-                      border: '1px solid #cbd5f5',
-                      background: '#f8fafc',
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 8,
-                      fontSize: 14,
-                    }}
-                  >
-                    <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={36} />
-                    <span>{badge.name}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ) : null}
-
-          <section>
-            <h3 style={{ margin: '0 0 12px', fontSize: 18 }}>Letzte Vergaben</h3>
+          <section
+            style={{
+              background: '#fff',
+              borderRadius: 24,
+              border: '1px solid rgba(15,23,42,0.12)',
+              boxShadow: '0 24px 48px rgba(15,23,42,0.08)',
+              padding: 24,
+              display: 'grid',
+              gap: 16,
+            }}
+          >
+            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0f172a' }}>Letzte Vergaben</h3>
             {logs.length === 0 ? (
-              <p style={{ margin: 0, color: '#64748b' }}>Noch keine Vergaben vorhanden.</p>
+              <p style={{ margin: 0, color: '#64748b', fontSize: 14 }}>Noch keine Vergaben vorhanden.</p>
             ) : (
               <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
                 {logs.map((entry) => (
                   <li
                     key={entry.id}
                     style={{
-                      border: '1px solid #d0d7e6',
-                      borderRadius: 12,
-                      padding: 12,
-                      background: '#f8fafc',
+                      border: '1px solid rgba(15,23,42,0.1)',
+                      borderRadius: 16,
+                      padding: 14,
+                      background: 'rgba(248,250,252,0.95)',
                       display: 'grid',
-                      gap: 4,
+                      gap: 6,
                     }}
                   >
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
-                      <strong style={{ fontSize: 16 }}>+{entry.xp} XP</strong>
+                      <strong style={{ fontSize: 15, color: '#0f172a' }}>+{entry.xp} XP</strong>
                       <span style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(entry.timestamp)}</span>
                     </div>
-                    <div style={{ fontSize: 14 }}>{entry.questName}</div>
+                    <div style={{ fontSize: 14, color: '#0f172a' }}>{entry.questName}</div>
                     {entry.note && (
                       <div style={{ fontSize: 12, color: '#475569' }}>{entry.note}</div>
                     )}


### PR DESCRIPTION
## Summary
- add a reusable profile card component that highlights a student's avatar, level, badges, and total XP
- replace the hand-built header in the student detail modal with the new card and refresh the surrounding styling

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cfdf486464832ca1cb3cb2840b555a