### PR TITLE
feat: redesign student profile experience

### DIFF
--- a/classquest/docs/ui-student-view.md
+++ b/classquest/docs/ui-student-view.md
@@ -1,0 +1,9 @@
+# Schüleransicht – Tastaturkürzel
+
+Die Schüleransicht unterstützt folgende Shortcuts:
+
+- **Pfeil nach links/rechts**: Navigiert zyklisch zum vorherigen bzw. nächsten Schüler in der Übersicht und im Detail-Overlay.
+- **Esc**: Schließt die Schülerdetailansicht sowie geöffnete Avatar-Zoom-Modals.
+- **Enter/Leertaste auf dem Avatar**: Öffnet den Avatar-Zoom.
+
+Die Navigation funktioniert nur, wenn kein Texteingabefeld fokussiert ist.

--- a/classquest/src/App.tsx
+++ b/classquest/src/App.tsx
@@ -13,7 +13,12 @@ import CommandPalette from '~/ui/shortcut/CommandPalette';
 import HelpOverlay from '~/ui/shortcut/HelpOverlay';
 import { useKeydown } from '~/ui/shortcut/KeyScope';
 import SeasonResetDialog from '~/ui/dialogs/SeasonResetDialog';
-import { EVENT_CLEAR_SELECTION, EVENT_SELECT_ALL, EVENT_UNDO_PERFORMED } from '~/ui/shortcut/events';
+import {
+  EVENT_CLEAR_SELECTION,
+  EVENT_NAVIGATE_TAB,
+  EVENT_SELECT_ALL,
+  EVENT_UNDO_PERFORMED,
+} from '~/ui/shortcut/events';
 
 type Tab = 'award' | 'leaderboard' | 'overview' | 'log' | 'manage' | 'info';
 
@@ -52,6 +57,18 @@ export default function App() {
       setTab('award');
     }
   }, [shouldShowFirstRun]);
+
+  useEffect(() => {
+    const handleNavigate = (event: Event) => {
+      const detail = (event as CustomEvent<{ tab?: Tab }>).detail;
+      if (!detail?.tab) {
+        return;
+      }
+      setTab(detail.tab);
+    };
+    window.addEventListener(EVENT_NAVIGATE_TAB, handleNavigate as EventListener);
+    return () => window.removeEventListener(EVENT_NAVIGATE_TAB, handleNavigate as EventListener);
+  }, []);
 
   const closeOverlays = useCallback(() => {
     setPaletteOpen(false);

--- a/classquest/src/__tests__/studentComponents.test.tsx
+++ b/classquest/src/__tests__/studentComponents.test.tsx
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+import StudentProfileCardV2 from '~/ui/components/student/StudentProfileCardV2';
+import { AvatarZoomModal } from '~/ui/components/ui/AvatarZoomModal';
+import { TrophyGrid } from '~/ui/components/badges/TrophyGrid';
+import { getNextStudentId } from '~/ui/student/getNextStudentId';
+import type { Badge, Student } from '~/types/models';
+
+vi.mock('~/ui/components/AwardBadgeButton', () => ({
+  __esModule: true,
+  default: () => <button type="button">Badge vergeben</button>,
+}));
+
+vi.mock('~/ui/avatar/AvatarView', () => ({
+  __esModule: true,
+  AvatarView: ({ student, size }: { student: { alias: string }; size: number }) => (
+    <div role="img">Avatar {student.alias} ({size})</div>
+  ),
+  default: ({ student, size }: { student: { alias: string }; size: number }) => (
+    <div role="img">Avatar {student.alias} ({size})</div>
+  ),
+}));
+
+describe('getNextStudentId', () => {
+  const students = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+
+  it('returns null when no students are present', () => {
+    expect(getNextStudentId(null, 'forward', [])).toBeNull();
+  });
+
+  it('returns first student when current is null (forward)', () => {
+    expect(getNextStudentId(null, 'forward', students)).toBe('a');
+  });
+
+  it('wraps around when moving forward from last student', () => {
+    expect(getNextStudentId('c', 'forward', students)).toBe('a');
+  });
+
+  it('wraps around when moving backward from first student', () => {
+    expect(getNextStudentId('a', 'backward', students)).toBe('c');
+  });
+});
+
+describe('component smoke tests', () => {
+  const baseStudent: Student = {
+    id: 'student-1',
+    alias: 'Alex',
+    xp: 120,
+    level: 3,
+    streaks: {},
+    lastAwardedDay: {},
+    badges: [],
+    avatarMode: 'procedural',
+    avatarPack: { stageKeys: [] },
+  };
+
+  it('renders StudentProfileCardV2 without crashing', () => {
+    const html = renderToString(
+      <StudentProfileCardV2
+        student={baseStudent}
+        xpPerLevel={100}
+        teamName="Team A"
+        categories={[{ name: 'Mathe', xp: 60 }]}
+        categoriesTotal={60}
+      />,
+    );
+    expect(html).toContain('Alex');
+    expect(html).toContain('Trophäenschrank');
+  });
+
+  it('renders AvatarZoomModal in open state', () => {
+    const html = renderToString(
+      <AvatarZoomModal
+        open
+        onClose={() => undefined}
+        student={{ alias: 'Alex', avatarMode: 'procedural', avatarPack: { stageKeys: [] }, level: 1, xp: 0 }}
+      />,
+    );
+    expect(html).toContain('Avatar von Alex');
+  });
+
+  it('renders TrophyGrid with badges', () => {
+    const badges: Badge[] = [
+      { id: 'badge-1', name: 'Rakete', description: 'Abgehoben', awardedAt: '2024-01-01T10:00:00Z' },
+    ];
+    const html = renderToString(<TrophyGrid badges={badges} />);
+    expect(html).toContain('Rakete');
+  });
+});

--- a/classquest/src/ui/components/BadgeIcon.tsx
+++ b/classquest/src/ui/components/BadgeIcon.tsx
@@ -54,7 +54,7 @@ export function BadgeIcon({ name, iconKey, size = 48 }: BadgeIconProps) {
         src={url}
         alt={name}
         title={name}
-        style={{ ...baseStyle, objectFit: 'cover' }}
+        style={{ ...baseStyle, objectFit: 'cover', imageRendering: 'crisp-edges' }}
       />
     );
   }

--- a/classquest/src/ui/components/badges/TrophyGrid.tsx
+++ b/classquest/src/ui/components/badges/TrophyGrid.tsx
@@ -1,0 +1,142 @@
+import { useId, useMemo, useState } from 'react';
+import { BadgeIcon } from '~/ui/components/BadgeIcon';
+import type { Badge } from '~/types/models';
+
+const tileStyle: React.CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: 12,
+  padding: 16,
+  borderRadius: 18,
+  border: '1px solid rgba(148,163,184,0.35)',
+  background: 'linear-gradient(180deg, rgba(248,250,252,0.85), rgba(226,232,240,0.75))',
+  boxShadow: '0 16px 40px rgba(15,23,42,0.12)',
+  transition: 'transform 0.18s ease, box-shadow 0.18s ease',
+};
+
+const tooltipStyle: React.CSSProperties = {
+  position: 'absolute',
+  bottom: '100%',
+  left: '50%',
+  transform: 'translate(-50%, -12px)',
+  padding: '10px 14px',
+  borderRadius: 12,
+  background: 'rgba(15,23,42,0.92)',
+  color: '#f8fafc',
+  minWidth: 200,
+  maxWidth: 260,
+  boxShadow: '0 12px 32px rgba(15,23,42,0.35)',
+  pointerEvents: 'none',
+  zIndex: 5,
+};
+
+const captionStyle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#0f172a',
+  textAlign: 'center',
+};
+
+type TrophyGridProps = {
+  badges: Badge[];
+  emptyMessage?: string;
+};
+
+function formatAwardedAt(value: string) {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return value;
+  }
+  try {
+    return new Date(timestamp).toLocaleString('de-DE', { dateStyle: 'medium', timeStyle: 'short' });
+  } catch (error) {
+    console.warn('Badge-Datum konnte nicht formatiert werden', error);
+    return new Date(timestamp).toLocaleString();
+  }
+}
+
+function TrophyTile({ badge }: { badge: Badge }) {
+  const [hover, setHover] = useState(false);
+  const tooltipId = useId();
+  const description = badge.description?.trim();
+  const awardedAt = useMemo(() => formatAwardedAt(badge.awardedAt), [badge.awardedAt]);
+
+  return (
+    <li style={{ position: 'relative' }}>
+      <button
+        type="button"
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        onFocus={() => setHover(true)}
+        onBlur={() => setHover(false)}
+        aria-describedby={tooltipId}
+        aria-label={`Abzeichen: ${badge.name}`}
+        style={{
+          ...tileStyle,
+          transform: hover ? 'translateY(-4px) scale(1.02)' : 'translateY(0)',
+          boxShadow: hover ? '0 22px 50px rgba(14,116,144,0.25)' : tileStyle.boxShadow,
+          cursor: 'pointer',
+        }}
+      >
+        <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={88} />
+        <span style={captionStyle}>{badge.name}</span>
+      </button>
+      <div
+        id={tooltipId}
+        role="tooltip"
+        aria-hidden={!hover}
+        style={{
+          ...tooltipStyle,
+          opacity: hover ? 1 : 0,
+          visibility: hover ? 'visible' : 'hidden',
+        }}
+      >
+        <strong style={{ display: 'block', fontSize: 14, marginBottom: 4 }}>{badge.name}</strong>
+        {description && <p style={{ margin: '0 0 6px', fontSize: 12 }}>{description}</p>}
+        <span style={{ fontSize: 12, opacity: 0.9 }}>Vergeben am {awardedAt}</span>
+      </div>
+    </li>
+  );
+}
+
+export function TrophyGrid({ badges, emptyMessage = 'Noch keine Abzeichen – starte mit einer Quest!' }: TrophyGridProps) {
+  const sortedBadges = useMemo(() => {
+    const copy = [...badges];
+    copy.sort((a, b) => {
+      const timeA = Date.parse(a.awardedAt);
+      const timeB = Date.parse(b.awardedAt);
+      if (Number.isNaN(timeA) && Number.isNaN(timeB)) return 0;
+      if (Number.isNaN(timeA)) return 1;
+      if (Number.isNaN(timeB)) return -1;
+      return timeB - timeA;
+    });
+    return copy;
+  }, [badges]);
+
+  if (sortedBadges.length === 0) {
+    return <p style={{ margin: 0, color: '#475569' }}>{emptyMessage}</p>;
+  }
+
+  return (
+    <ul
+      role="list"
+      style={{
+        listStyle: 'none',
+        margin: 0,
+        padding: 0,
+        display: 'grid',
+        gap: 18,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+      }}
+    >
+      {sortedBadges.map((badge) => (
+        <TrophyTile key={`${badge.id}-${badge.awardedAt}`} badge={badge} />
+      ))}
+    </ul>
+  );
+}
+
+export default TrophyGrid;

--- a/classquest/src/ui/components/student/StudentProfileCardV2.tsx
+++ b/classquest/src/ui/components/student/StudentProfileCardV2.tsx
@@ -1,0 +1,320 @@
+import { useMemo, useState } from 'react';
+import { AvatarView } from '~/ui/avatar/AvatarView';
+import AwardBadgeButton from '~/ui/components/AwardBadgeButton';
+import { TrophyGrid } from '~/ui/components/badges/TrophyGrid';
+import { AvatarZoomModal } from '~/ui/components/ui/AvatarZoomModal';
+import type { Badge, Student } from '~/types/models';
+import { navigateToAwardScreen } from '~/ui/student/navigate';
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+
+const formatNumber = (value: number) => numberFormatter.format(Math.max(0, Math.round(value)));
+
+type StudentCategoryStat = {
+  name: string;
+  xp: number;
+};
+
+type StudentProfileCardV2Props = {
+  student: Student;
+  xpPerLevel: number;
+  teamName?: string | null;
+  categories: StudentCategoryStat[];
+  categoriesTotal: number;
+  onAwardQuest?: (student: Student) => void;
+};
+
+type LevelProgress = {
+  inLevel: number;
+  remaining: number;
+  ratio: number;
+  nextLevel: number;
+  totalXp: number;
+};
+
+function computeLevelProgress(student: Student, xpPerLevelSetting: number): LevelProgress {
+  const xpPerLevel = Math.max(1, Math.round(xpPerLevelSetting));
+  const level = Math.max(1, Math.round(student.level ?? 1));
+  const xpTotal = Math.max(0, Math.round(student.xp ?? 0));
+  const baseXp = (level - 1) * xpPerLevel;
+  const rawInLevel = xpTotal - baseXp;
+  const inLevel = Math.max(0, Math.min(xpPerLevel, rawInLevel));
+  const remaining = Math.max(0, xpPerLevel - inLevel);
+  const ratio = xpPerLevel > 0 ? Math.min(1, inLevel / xpPerLevel) : 0;
+  return {
+    inLevel,
+    remaining,
+    ratio,
+    nextLevel: level + 1,
+    totalXp: xpTotal,
+  };
+}
+
+function normalizeCategoryName(name: string) {
+  if (!name || name === 'uncategorized') {
+    return 'Sonstiges';
+  }
+  return name;
+}
+
+function sortBadges(badges: Badge[]): Badge[] {
+  const list = [...badges];
+  list.sort((a, b) => {
+    const timeA = Date.parse(a.awardedAt);
+    const timeB = Date.parse(b.awardedAt);
+    if (Number.isNaN(timeA) && Number.isNaN(timeB)) return 0;
+    if (Number.isNaN(timeA)) return 1;
+    if (Number.isNaN(timeB)) return -1;
+    return timeB - timeA;
+  });
+  return list;
+}
+
+export function StudentProfileCardV2({
+  student,
+  xpPerLevel,
+  teamName,
+  categories,
+  categoriesTotal,
+  onAwardQuest,
+}: StudentProfileCardV2Props) {
+  const [zoomOpen, setZoomOpen] = useState(false);
+  const progress = useMemo(() => computeLevelProgress(student, xpPerLevel), [student, xpPerLevel]);
+  const badges = useMemo(() => sortBadges(student.badges ?? []), [student.badges]);
+  const topCategories = useMemo(() => {
+    const relevant = categories.filter((entry) => entry.xp > 0);
+    relevant.sort((a, b) => b.xp - a.xp);
+    return relevant.slice(0, 3);
+  }, [categories]);
+
+  const handleAwardQuest = () => {
+    if (onAwardQuest) {
+      onAwardQuest(student);
+      return;
+    }
+    navigateToAwardScreen(student.id);
+  };
+
+  const openZoom = () => setZoomOpen(true);
+  const closeZoom = () => setZoomOpen(false);
+
+  const levelPill = (
+    <span
+      style={{
+        padding: '6px 14px',
+        borderRadius: 999,
+        background: 'linear-gradient(90deg, #f97316, #fb7185)',
+        color: '#fff',
+        fontWeight: 700,
+        fontSize: 14,
+        boxShadow: '0 12px 28px rgba(249,115,22,0.35)',
+      }}
+    >
+      Level {student.level}
+    </span>
+  );
+
+  return (
+    <article
+      aria-label={`Profil von ${student.alias}`}
+      style={{
+        display: 'grid',
+        gap: 24,
+        padding: 28,
+        borderRadius: 32,
+        border: '1px solid rgba(148,163,184,0.35)',
+        background: 'linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.82))',
+        boxShadow: '0 32px 80px rgba(15,23,42,0.35)',
+        color: '#f8fafc',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          flexWrap: 'wrap',
+          gap: 24,
+          alignItems: 'stretch',
+        }}
+      >
+        <button
+          type="button"
+          onClick={openZoom}
+          aria-label="Profilbild vergrößern"
+          style={{
+            border: 'none',
+            padding: 0,
+            background: 'transparent',
+            cursor: 'zoom-in',
+            flex: '0 0 200px',
+            borderRadius: 28,
+            position: 'relative',
+            boxShadow: '0 24px 60px rgba(14,116,144,0.45)',
+          }}
+        >
+          <AvatarView
+            student={{
+              alias: student.alias,
+              avatarMode: student.avatarMode,
+              avatarPack: student.avatarPack,
+              level: student.level,
+              xp: student.xp,
+            }}
+            size={200}
+            rounded="xl"
+            style={{
+              width: '100%',
+              height: '100%',
+              borderRadius: 28,
+              boxShadow: '0 18px 48px rgba(14,116,144,0.4)',
+            }}
+          />
+        </button>
+        <div
+          style={{
+            flex: '1 1 280px',
+            minWidth: 240,
+            display: 'grid',
+            gap: 18,
+            alignContent: 'start',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 16,
+              justifyContent: 'space-between',
+              alignItems: 'flex-start',
+            }}
+          >
+            <div style={{ display: 'grid', gap: 6, minWidth: 0 }}>
+              <h1
+                style={{
+                  margin: 0,
+                  fontSize: 28,
+                  fontWeight: 800,
+                  letterSpacing: '-0.01em',
+                  color: '#f8fafc',
+                }}
+              >
+                {student.alias}
+              </h1>
+              <div style={{ fontSize: 14, color: 'rgba(226,232,240,0.85)' }}>
+                Gesamt: {formatNumber(progress.totalXp)} XP
+                {teamName ? ` · Team ${teamName}` : ''}
+              </div>
+            </div>
+            {levelPill}
+          </div>
+          <div style={{ display: 'grid', gap: 10 }}>
+            <div style={{ fontSize: 14, color: 'rgba(226,232,240,0.9)' }}>
+              {formatNumber(progress.inLevel)} / {formatNumber(xpPerLevel)} XP in diesem Level
+            </div>
+            <div
+              aria-hidden
+              style={{
+                height: 14,
+                borderRadius: 999,
+                background: 'rgba(30,41,59,0.65)',
+                overflow: 'hidden',
+                border: '1px solid rgba(148,163,184,0.45)',
+              }}
+            >
+              <div
+                style={{
+                  width: `${Math.round(progress.ratio * 100)}%`,
+                  height: '100%',
+                  borderRadius: 999,
+                  background: 'linear-gradient(90deg, #22d3ee, #38bdf8)',
+                  boxShadow: '0 12px 28px rgba(8,145,178,0.45)',
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 13, color: 'rgba(226,232,240,0.8)' }}>
+              {formatNumber(progress.remaining)} XP bis Level {progress.nextLevel}
+            </div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              gap: 12,
+              alignItems: 'center',
+            }}
+          >
+            <button
+              type="button"
+              onClick={handleAwardQuest}
+              style={{
+                padding: '10px 18px',
+                borderRadius: 999,
+                border: 'none',
+                background: 'linear-gradient(90deg, #f97316, #facc15)',
+                color: '#0f172a',
+                fontWeight: 700,
+                cursor: 'pointer',
+                boxShadow: '0 16px 36px rgba(250,204,21,0.35)',
+              }}
+            >
+              ⚡ XP/Quest vergeben
+            </button>
+            <AwardBadgeButton student={student} />
+          </div>
+        </div>
+      </div>
+
+      <section style={{ display: 'grid', gap: 10 }}>
+        <h2 style={{ margin: 0, fontSize: 18, color: '#e2e8f0' }}>Top-Kategorien</h2>
+        {topCategories.length === 0 ? (
+          <p style={{ margin: 0, color: 'rgba(226,232,240,0.75)' }}>Noch keine Kategorien vergeben.</p>
+        ) : (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+            {topCategories.map((entry) => {
+              const ratio = categoriesTotal > 0 ? Math.round((entry.xp / categoriesTotal) * 100) : 0;
+              return (
+                <span
+                  key={entry.name}
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: 999,
+                    background: 'rgba(148,163,184,0.18)',
+                    border: '1px solid rgba(148,163,184,0.35)',
+                    fontSize: 13,
+                    color: '#f8fafc',
+                  }}
+                >
+                  <strong style={{ fontWeight: 700 }}>{normalizeCategoryName(entry.name)}</strong>{' '}
+                  · {formatNumber(entry.xp)} XP ({ratio}%)
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }}>
+        <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <h2 style={{ margin: 0, fontSize: 20, color: '#f8fafc' }}>Trophäenschrank</h2>
+          <span style={{ fontSize: 13, color: 'rgba(226,232,240,0.8)' }}>
+            {badges.length} {badges.length === 1 ? 'Abzeichen' : 'Abzeichen'}
+          </span>
+        </header>
+        <TrophyGrid badges={badges} />
+      </section>
+
+      <AvatarZoomModal
+        open={zoomOpen}
+        onClose={closeZoom}
+        student={{
+          alias: student.alias,
+          avatarMode: student.avatarMode,
+          avatarPack: student.avatarPack,
+          level: student.level,
+          xp: student.xp,
+        }}
+      />
+    </article>
+  );
+}
+
+export default StudentProfileCardV2;

--- a/classquest/src/ui/components/ui/AvatarZoomModal.tsx
+++ b/classquest/src/ui/components/ui/AvatarZoomModal.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useId, useRef } from 'react';
+import { AvatarView, type AvatarViewStudent } from '~/ui/avatar/AvatarView';
+
+const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+type AvatarZoomModalProps = {
+  open: boolean;
+  student: AvatarViewStudent;
+  onClose: () => void;
+};
+
+export function AvatarZoomModal({ open, student, onClose }: AvatarZoomModalProps) {
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+  const headingId = useId();
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const closeButton = closeButtonRef.current;
+    if (closeButton) {
+      closeButton.focus({ preventScroll: true });
+    }
+    return () => {
+      const previous = previousFocusRef.current;
+      if (previous && typeof previous.focus === 'function') {
+        previous.focus({ preventScroll: true });
+      }
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const getFocusableElements = () => {
+    if (!dialogRef.current) {
+      return [] as HTMLElement[];
+    }
+    return Array.from(dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+      (element) => !element.hasAttribute('disabled'),
+    );
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose();
+      return;
+    }
+
+    if (event.key !== 'Tab') {
+      return;
+    }
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+
+    if (event.shiftKey) {
+      if (active === first || !active) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+      return;
+    }
+
+    if (active === last || !active) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  return (
+    <div
+      role="presentation"
+      onClick={handleClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(15,23,42,0.72)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 24,
+        zIndex: 60,
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleKeyDown}
+        style={{
+          background: 'linear-gradient(180deg, rgba(15,23,42,0.92), rgba(15,23,42,0.86))',
+          borderRadius: 28,
+          padding: 24,
+          width: 'min(90vw, 520px)',
+          boxShadow: '0 28px 80px rgba(15,23,42,0.45)',
+          border: '1px solid rgba(148,163,184,0.3)',
+          display: 'grid',
+          gap: 16,
+        }}
+      >
+        <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+          <h2 id={headingId} style={{ margin: 0, fontSize: 18, color: '#e2e8f0', fontWeight: 600 }}>
+            Avatar von {student.alias}
+          </h2>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={handleClose}
+            aria-label="Zoom schließen"
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: 999,
+              border: '1px solid rgba(148,163,184,0.4)',
+              background: 'rgba(30,41,59,0.6)',
+              color: '#f8fafc',
+              fontSize: 22,
+              fontWeight: 600,
+              cursor: 'pointer',
+            }}
+          >
+            ×
+          </button>
+        </header>
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
+          <AvatarView
+            student={student}
+            size={360}
+            rounded="xl"
+            style={{
+              width: 'min(80vw, 440px)',
+              height: 'min(80vw, 440px)',
+              borderRadius: 36,
+              boxShadow: '0 24px 80px rgba(14,116,144,0.45)',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AvatarZoomModal;

--- a/classquest/src/ui/screens/ClassOverviewScreen.tsx
+++ b/classquest/src/ui/screens/ClassOverviewScreen.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useApp } from '~/app/AppContext';
-import { AvatarView } from '~/ui/avatar/AvatarView';
-import AwardBadgeButton from '~/ui/components/AwardBadgeButton';
-import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import { selectLogsForStudent, selectStudentById } from '~/core/selectors/student';
 import { selectStudentCategoryXp } from '~/core/selectors/badges';
 import type { LogEntry, Student } from '~/types/models';
+import { AvatarView } from '~/ui/avatar/AvatarView';
+import StudentProfileCardV2 from '~/ui/components/student/StudentProfileCardV2';
+import { getNextStudentId } from '~/ui/student/getNextStudentId';
+import { shouldIgnoreNavigation } from '~/ui/utils/isTextInputLike';
 
 const numberFormatter = new Intl.NumberFormat('de-DE');
 
@@ -20,31 +21,6 @@ function formatTimestamp(timestamp: number) {
     console.warn('Zeitstempel konnte nicht formatiert werden', error);
     return new Date(timestamp).toLocaleString();
   }
-}
-
-type LevelProgress = {
-  inLevel: number;
-  remaining: number;
-  ratio: number;
-  xpPerLevel: number;
-  nextLevel: number;
-};
-
-function computeLevelProgress(student: Student, xpPerLevelSetting: number): LevelProgress {
-  const xpPerLevel = Math.max(1, Math.round(xpPerLevelSetting));
-  const level = Math.max(1, Math.round(student.level ?? 1));
-  const baseXp = (level - 1) * xpPerLevel;
-  const rawInLevel = student.xp - baseXp;
-  const inLevel = Math.max(0, Math.min(xpPerLevel, rawInLevel));
-  const ratio = xpPerLevel > 0 ? Math.min(1, inLevel / xpPerLevel) : 0;
-  const remaining = Math.max(0, xpPerLevel - inLevel);
-  return {
-    inLevel,
-    remaining,
-    ratio,
-    xpPerLevel,
-    nextLevel: level + 1,
-  };
 }
 
 type CategoryEntry = {
@@ -71,15 +47,23 @@ const sidebarStyle: CSSProperties = {
 };
 const listStyle: CSSProperties = { listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 8 };
 const mainStyle: CSSProperties = { flex: 1, minWidth: 0, overflowY: 'auto', padding: 24 };
-const panelStyle: CSSProperties = {
+const detailsStyle: CSSProperties = {
   background: '#fff',
-  borderRadius: 18,
+  borderRadius: 24,
   border: '1px solid #d0d7e6',
-  padding: 20,
-  display: 'grid',
-  gap: 16,
-  boxShadow: '0 12px 32px rgba(15,23,42,0.05)',
+  boxShadow: '0 18px 48px rgba(15,23,42,0.08)',
+  overflow: 'hidden',
 };
+const summaryStyle: CSSProperties = {
+  margin: 0,
+  padding: '18px 24px',
+  fontSize: 18,
+  fontWeight: 700,
+  cursor: 'pointer',
+  color: '#0f172a',
+  listStyle: 'none',
+};
+const detailsContentStyle: CSSProperties = { padding: '0 24px 24px', display: 'grid', gap: 16 };
 
 export default function ClassOverviewScreen() {
   const { state } = useApp();
@@ -101,6 +85,25 @@ export default function ClassOverviewScreen() {
       }
       return students[0]?.id ?? null;
     });
+  }, [students]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+        return;
+      }
+      if (shouldIgnoreNavigation(event)) {
+        return;
+      }
+      if (students.length === 0) {
+        return;
+      }
+      event.preventDefault();
+      const direction = event.key === 'ArrowRight' ? 'forward' : 'backward';
+      setSelectedId((current) => getNextStudentId(current, direction, students) ?? current);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
   }, [students]);
 
   const selectedStudent = useMemo(
@@ -203,170 +206,90 @@ export default function ClassOverviewScreen() {
 }
 
 function ProfilePane({ student, teamName, logs, categories, categoriesTotal, xpPerLevel }: ProfilePaneProps) {
-  const badges = student.badges ?? [];
-  const progress = computeLevelProgress(student, xpPerLevel);
-
   return (
     <div style={{ display: 'grid', gap: 24, paddingBottom: 24 }}>
-      <section style={{ ...panelStyle, paddingBottom: 24 }}>
-        <header style={{ display: 'flex', gap: 20, alignItems: 'center' }}>
-          <AvatarView
-            student={{
-              alias: student.alias,
-              avatarMode: student.avatarMode,
-              avatarPack: student.avatarPack,
-              level: student.level,
-              xp: student.xp,
-            }}
-            size={108}
-            rounded="xl"
-          />
-          <div style={{ minWidth: 0, display: 'grid', gap: 6 }}>
-            <h1 style={{ margin: 0, fontSize: 26 }}>{student.alias}</h1>
-            <p style={{ margin: 0, color: '#475569', fontSize: 14 }}>
-              {formatNumber(student.xp)} XP · Level {student.level}
-              {teamName ? ` · ${teamName}` : ''}
-            </p>
-            <div style={{ marginTop: 6 }}>
-              <div style={{ fontSize: 13, color: '#475569' }}>
-                {formatNumber(progress.inLevel)} / {formatNumber(progress.xpPerLevel)} XP in diesem Level
-              </div>
-              <div
-                aria-hidden
-                style={{
-                  marginTop: 6,
-                  height: 10,
-                  borderRadius: 999,
-                  background: '#e2e8f0',
-                  overflow: 'hidden',
-                }}
-              >
-                <div
-                  style={{
-                    width: `${Math.round(progress.ratio * 100)}%`,
-                    height: '100%',
-                    background: 'linear-gradient(90deg, #34d399, #22d3ee)',
-                    transition: 'width 0.2s ease',
-                  }}
-                />
-              </div>
-              <div style={{ fontSize: 12, color: '#64748b', marginTop: 6 }}>
-                {formatNumber(progress.remaining)} XP bis Level {progress.nextLevel}
-              </div>
-            </div>
-          </div>
-        </header>
-      </section>
+      <StudentProfileCardV2
+        student={student}
+        xpPerLevel={xpPerLevel}
+        teamName={teamName}
+        categories={categories}
+        categoriesTotal={categoriesTotal}
+      />
 
-      <section style={panelStyle}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
-          <h2 style={{ margin: 0, fontSize: 20 }}>Badges</h2>
-          <AwardBadgeButton student={student} />
-        </div>
-        {badges.length === 0 ? (
-          <p style={{ margin: 0, color: '#475569' }}>Noch keine Badges vergeben.</p>
-        ) : (
-          <ul
-            style={{
-              listStyle: 'none',
-              margin: 0,
-              padding: 0,
-              display: 'flex',
-              flexWrap: 'wrap',
-              gap: 12,
-            }}
-          >
-            {badges.map((badge) => (
-              <li
-                key={`${badge.id}-${badge.awardedAt}`}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 10,
-                  borderRadius: 999,
-                  border: '1px solid #cbd5f5',
-                  padding: '6px 12px',
-                  background: '#f8fafc',
-                }}
-              >
-                <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={42} />
-                <span style={{ fontSize: 14 }}>{badge.name}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-
-      <section style={panelStyle}>
-        <h2 style={{ margin: 0, fontSize: 20 }}>XP nach Kategorie</h2>
-        {categories.length === 0 ? (
-          <p style={{ margin: 0, color: '#475569' }}>Keine Einträge vorhanden.</p>
-        ) : (
-          <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
-            {categories.map((entry) => {
-              const ratio = categoriesTotal > 0 ? entry.xp / categoriesTotal : 0;
-              const label = entry.name === 'uncategorized' ? 'Sonstiges' : entry.name;
-              return (
-                <li key={entry.name} style={{ display: 'grid', gap: 6 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontSize: 14 }}>
-                    <span style={{ fontWeight: 600 }}>{label}</span>
-                    <span style={{ color: '#475569' }}>
-                      {formatNumber(entry.xp)} XP · {Math.round(ratio * 100)}%
-                    </span>
-                  </div>
-                  <div
-                    aria-hidden
-                    style={{
-                      height: 8,
-                      borderRadius: 999,
-                      background: '#e2e8f0',
-                      overflow: 'hidden',
-                    }}
-                  >
+      <details open style={detailsStyle}>
+        <summary style={summaryStyle}>XP nach Kategorie (voll)</summary>
+        <div style={detailsContentStyle}>
+          {categories.length === 0 ? (
+            <p style={{ margin: 0, color: '#475569' }}>Keine Einträge vorhanden.</p>
+          ) : (
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
+              {categories.map((entry) => {
+                const ratio = categoriesTotal > 0 ? entry.xp / categoriesTotal : 0;
+                const label = entry.name === 'uncategorized' ? 'Sonstiges' : entry.name;
+                return (
+                  <li key={entry.name} style={{ display: 'grid', gap: 6 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontSize: 14 }}>
+                      <span style={{ fontWeight: 600 }}>{label}</span>
+                      <span style={{ color: '#475569' }}>
+                        {formatNumber(entry.xp)} XP · {Math.round(ratio * 100)}%
+                      </span>
+                    </div>
                     <div
+                      aria-hidden
                       style={{
-                        width: `${Math.round(ratio * 100)}%`,
-                        height: '100%',
-                        background: '#5b8def',
+                        height: 8,
+                        borderRadius: 999,
+                        background: '#e2e8f0',
+                        overflow: 'hidden',
                       }}
-                    />
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-      </section>
+                    >
+                      <div
+                        style={{
+                          width: `${Math.round(ratio * 100)}%`,
+                          height: '100%',
+                          background: '#5b8def',
+                        }}
+                      />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </details>
 
-      <section style={panelStyle}>
-        <h2 style={{ margin: 0, fontSize: 20 }}>Letzte Vergaben</h2>
-        {logs.length === 0 ? (
-          <p style={{ margin: 0, color: '#475569' }}>Noch keine Vergaben aufgezeichnet.</p>
-        ) : (
-          <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
-            {logs.map((entry) => (
-              <li
-                key={entry.id}
-                style={{
-                  border: '1px solid #d0d7e6',
-                  borderRadius: 14,
-                  padding: 14,
-                  background: '#f8fafc',
-                  display: 'grid',
-                  gap: 6,
-                }}
-              >
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
-                  <strong style={{ fontSize: 15 }}>+{formatNumber(entry.xp)} XP</strong>
-                  <span style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(entry.timestamp)}</span>
-                </div>
-                <div style={{ fontSize: 14 }}>{entry.questName}</div>
-                {entry.note && <div style={{ fontSize: 12, color: '#475569' }}>{entry.note}</div>}
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
+      <details open style={detailsStyle}>
+        <summary style={summaryStyle}>Letzte Vergaben</summary>
+        <div style={detailsContentStyle}>
+          {logs.length === 0 ? (
+            <p style={{ margin: 0, color: '#475569' }}>Noch keine Vergaben aufgezeichnet.</p>
+          ) : (
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
+              {logs.map((entry) => (
+                <li
+                  key={entry.id}
+                  style={{
+                    border: '1px solid #d0d7e6',
+                    borderRadius: 14,
+                    padding: 14,
+                    background: '#f8fafc',
+                    display: 'grid',
+                    gap: 6,
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
+                    <strong style={{ fontSize: 15 }}>+{formatNumber(entry.xp)} XP</strong>
+                    <span style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(entry.timestamp)}</span>
+                  </div>
+                  <div style={{ fontSize: 14 }}>{entry.questName}</div>
+                  {entry.note && <div style={{ fontSize: 12, color: '#475569' }}>{entry.note}</div>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </details>
     </div>
   );
 }

--- a/classquest/src/ui/screens/ManageScreen.tsx
+++ b/classquest/src/ui/screens/ManageScreen.tsx
@@ -5,7 +5,6 @@ import AsyncButton from '~/ui/feedback/AsyncButton';
 import { useFeedback } from '~/ui/feedback/FeedbackProvider';
 import { EVENT_EXPORT_DATA, EVENT_IMPORT_DATA, EVENT_OPEN_SEASON_RESET } from '~/ui/shortcut/events';
 import { deleteBlob, getObjectURL, putBlob } from '~/services/blobStore';
-import { selectLogsForStudent, selectStudentById } from '~/core/selectors/student';
 import { AVATAR_STAGE_COUNT } from '~/core/avatarStages';
 import { DEFAULT_SETTINGS } from '~/core/config';
 import StudentDetailScreen from '~/ui/screens/StudentDetailScreen';
@@ -998,19 +997,6 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
     setDetailStudentId(null);
   }, []);
 
-  const detailStudent = useMemo(
-    () => selectStudentById({ students: state.students }, detailStudentId),
-    [state.students, detailStudentId],
-  );
-
-  const detailLogs = useMemo(
-    () =>
-      detailStudentId
-        ? selectLogsForStudent({ logs: state.logs }, detailStudentId, 50)
-        : [],
-    [state.logs, detailStudentId],
-  );
-
   // Rename to avoid `Identifier "categories" has already been declared` conflicts
   const catList = useMemo(() => state.categories ?? [], [state.categories]);
 
@@ -1021,12 +1007,6 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
     },
     [catList],
   );
-
-  useEffect(() => {
-    if (detailStudentId && !detailStudent) {
-      setDetailStudentId(null);
-    }
-  }, [detailStudentId, detailStudent]);
 
   const addStudent = useCallback(() => {
     const trimmed = alias.trim();
@@ -2229,8 +2209,12 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
           {importError && <span style={{ color: '#b91c1c', fontWeight: 600 }}>{importError}</span>}
         </div>
       </CollapsibleSection>
-      {detailStudent && (
-        <StudentDetailScreen student={detailStudent} logs={detailLogs} onClose={closeStudentDetail} />
+      {detailStudentId && (
+        <StudentDetailScreen
+          studentId={detailStudentId}
+          onClose={closeStudentDetail}
+          onSelectStudent={(id) => setDetailStudentId(id)}
+        />
       )}
     </div>
   );

--- a/classquest/src/ui/screens/StudentDetailScreen.tsx
+++ b/classquest/src/ui/screens/StudentDetailScreen.tsx
@@ -1,11 +1,45 @@
-import { useEffect } from 'react';
-import type { LogEntry, Student } from '~/types/models';
-import ProfileCard from '~/ui/components/ProfileCard';
+import { useEffect, useMemo, type CSSProperties } from 'react';
+import { useApp } from '~/app/AppContext';
+import { selectLogsForStudent, selectStudentById } from '~/core/selectors/student';
+import { selectStudentCategoryXp } from '~/core/selectors/badges';
+import StudentProfileCardV2 from '~/ui/components/student/StudentProfileCardV2';
+import { getNextStudentId } from '~/ui/student/getNextStudentId';
+import { shouldIgnoreNavigation } from '~/ui/utils/isTextInputLike';
+import { navigateToAwardScreen } from '~/ui/student/navigate';
+
+const detailsStyle: CSSProperties = {
+  background: '#fff',
+  borderRadius: 24,
+  border: '1px solid rgba(148,163,184,0.35)',
+  boxShadow: '0 18px 48px rgba(15,23,42,0.15)',
+  overflow: 'hidden',
+};
+
+const summaryStyle: CSSProperties = {
+  margin: 0,
+  padding: '18px 24px',
+  fontSize: 18,
+  fontWeight: 700,
+  cursor: 'pointer',
+  color: '#0f172a',
+  listStyle: 'none',
+};
+
+const detailsContentStyle: CSSProperties = {
+  padding: '0 24px 24px',
+  display: 'grid',
+  gap: 16,
+};
 
 type StudentDetailScreenProps = {
-  student: Pick<Student, 'id' | 'alias' | 'xp' | 'level' | 'badges' | 'avatarMode' | 'avatarPack'>;
-  logs: LogEntry[];
+  studentId: string;
   onClose: () => void;
+  onSelectStudent: (studentId: string) => void;
+};
+
+type CategoryEntry = {
+  name: string;
+  xp: number;
 };
 
 function formatTimestamp(timestamp: number) {
@@ -17,17 +51,87 @@ function formatTimestamp(timestamp: number) {
   }
 }
 
-export default function StudentDetailScreen({ student, logs, onClose }: StudentDetailScreenProps) {
+export default function StudentDetailScreen({ studentId, onClose, onSelectStudent }: StudentDetailScreenProps) {
+  const { state } = useApp();
+
+  const student = useMemo(
+    () => selectStudentById({ students: state.students }, studentId),
+    [state.students, studentId],
+  );
+
+  const logs = useMemo(
+    () => selectLogsForStudent({ logs: state.logs }, studentId, 50),
+    [state.logs, studentId],
+  );
+
+  const categories = useMemo(() => {
+    if (!student) {
+      return [] as CategoryEntry[];
+    }
+    const totals = selectStudentCategoryXp(state, student);
+    const entries = Object.entries(totals).map(([name, xp]) => ({ name, xp }));
+    entries.sort((a, b) => b.xp - a.xp);
+    return entries;
+  }, [state, student]);
+
+  const categoriesTotal = useMemo(
+    () => categories.reduce((sum, entry) => sum + entry.xp, 0),
+    [categories],
+  );
+
+  const xpPerLevel = Math.max(1, state.settings.xpPerLevel || 1);
+
+  const teamName = useMemo(() => {
+    if (!student?.teamId) {
+      return null;
+    }
+    return state.teams.find((team) => team.id === student.teamId)?.name ?? null;
+  }, [student?.teamId, state.teams]);
+
+  const sortedStudents = useMemo(() => {
+    const list = [...state.students];
+    list.sort((a, b) => a.alias.localeCompare(b.alias, 'de'));
+    return list;
+  }, [state.students]);
+
   useEffect(() => {
-    const handleKey = (event: KeyboardEvent) => {
+    if (!student) {
+      onClose();
+    }
+  }, [student, onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.preventDefault();
         onClose();
+        return;
+      }
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+        return;
+      }
+      if (shouldIgnoreNavigation(event)) {
+        return;
+      }
+      const direction = event.key === 'ArrowRight' ? 'forward' : 'backward';
+      const nextId = getNextStudentId(studentId, direction, sortedStudents);
+      if (nextId) {
+        event.preventDefault();
+        onSelectStudent(nextId);
       }
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose]);
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [studentId, sortedStudents, onClose, onSelectStudent]);
+
+  if (!student) {
+    return null;
+  }
+
+  const handleAwardQuest = () => {
+    navigateToAwardScreen(student.id);
+    onClose();
+  };
 
   return (
     <div
@@ -38,90 +142,130 @@ export default function StudentDetailScreen({ student, logs, onClose }: StudentD
       style={{
         position: 'fixed',
         inset: 0,
-        background: 'rgba(15,23,42,0.55)',
+        background: 'rgba(15,23,42,0.65)',
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
         padding: 24,
-        zIndex: 50,
+        zIndex: 60,
       }}
     >
       <div
         role="document"
         onClick={(event) => event.stopPropagation()}
         style={{
-          background: 'transparent',
-          borderRadius: 24,
-          maxWidth: 560,
-          width: '100%',
-          maxHeight: '90vh',
+          width: 'min(920px, 100%)',
+          maxHeight: '92vh',
           overflowY: 'auto',
+          borderRadius: 32,
+          padding: '18px 0 32px',
         }}
       >
-        <div style={{ display: 'flex', justifyContent: 'flex-end', padding: 8 }}>
+        <div style={{ display: 'flex', justifyContent: 'flex-end', padding: '0 24px 12px' }}>
           <button
             type="button"
             onClick={onClose}
             aria-label="Detailansicht schließen"
             style={{
-              border: 'none',
-              background: 'rgba(15,23,42,0.06)',
+              border: '1px solid rgba(148,163,184,0.4)',
+              background: 'rgba(15,23,42,0.08)',
               color: '#0f172a',
               borderRadius: 999,
-              width: 36,
-              height: 36,
-              fontSize: 20,
+              width: 40,
+              height: 40,
+              fontSize: 22,
+              fontWeight: 600,
               cursor: 'pointer',
-              lineHeight: 1,
             }}
           >
             ×
           </button>
         </div>
-        <div style={{ padding: '0 24px 24px', display: 'grid', gap: 24 }}>
-          <ProfileCard studentId={student.id} titleId="student-detail-title" />
-
-          <section
-            style={{
-              background: '#fff',
-              borderRadius: 24,
-              border: '1px solid rgba(15,23,42,0.12)',
-              boxShadow: '0 24px 48px rgba(15,23,42,0.08)',
-              padding: 24,
-              display: 'grid',
-              gap: 16,
-            }}
+        <div style={{ padding: '0 24px', display: 'grid', gap: 24 }}>
+          <h2
+            id="student-detail-title"
+            style={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}
           >
-            <h3 style={{ margin: 0, fontSize: 18, fontWeight: 700, color: '#0f172a' }}>Letzte Vergaben</h3>
-            {logs.length === 0 ? (
-              <p style={{ margin: 0, color: '#64748b', fontSize: 14 }}>Noch keine Vergaben vorhanden.</p>
-            ) : (
-              <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
-                {logs.map((entry) => (
-                  <li
-                    key={entry.id}
-                    style={{
-                      border: '1px solid rgba(15,23,42,0.1)',
-                      borderRadius: 16,
-                      padding: 14,
-                      background: 'rgba(248,250,252,0.95)',
-                      display: 'grid',
-                      gap: 6,
-                    }}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
-                      <strong style={{ fontSize: 15, color: '#0f172a' }}>+{entry.xp} XP</strong>
-                      <span style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(entry.timestamp)}</span>
-                    </div>
-                    <div style={{ fontSize: 14, color: '#0f172a' }}>{entry.questName}</div>
-                    {entry.note && (
-                      <div style={{ fontSize: 12, color: '#475569' }}>{entry.note}</div>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </section>
+            {student.alias}
+          </h2>
+          <StudentProfileCardV2
+            student={student}
+            xpPerLevel={xpPerLevel}
+            teamName={teamName}
+            categories={categories}
+            categoriesTotal={categoriesTotal}
+            onAwardQuest={() => handleAwardQuest()}
+          />
+
+          <details open style={detailsStyle}>
+            <summary style={summaryStyle}>XP nach Kategorie (voll)</summary>
+            <div style={detailsContentStyle}>
+              {categories.length === 0 ? (
+                <p style={{ margin: 0, color: '#475569' }}>Keine Einträge vorhanden.</p>
+              ) : (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
+                  {categories.map((entry) => {
+                    const ratio = categoriesTotal > 0 ? entry.xp / categoriesTotal : 0;
+                    const label = entry.name === 'uncategorized' ? 'Sonstiges' : entry.name;
+                    return (
+                      <li key={entry.name} style={{ display: 'grid', gap: 6 }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', gap: 12, fontSize: 14 }}>
+                          <span style={{ fontWeight: 600 }}>{label}</span>
+                          <span style={{ color: '#475569' }}>
+                            {Math.round(ratio * 100)}% · {entry.xp.toLocaleString('de-DE')} XP
+                          </span>
+                        </div>
+                        <div
+                          aria-hidden
+                          style={{ height: 8, borderRadius: 999, background: '#e2e8f0', overflow: 'hidden' }}
+                        >
+                          <div
+                            style={{
+                              width: `${Math.round(ratio * 100)}%`,
+                              height: '100%',
+                              background: '#5b8def',
+                            }}
+                          />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </details>
+
+          <details open style={detailsStyle}>
+            <summary style={summaryStyle}>Letzte Vergaben</summary>
+            <div style={detailsContentStyle}>
+              {logs.length === 0 ? (
+                <p style={{ margin: 0, color: '#475569' }}>Noch keine Vergaben aufgezeichnet.</p>
+              ) : (
+                <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 12 }}>
+                  {logs.map((entry) => (
+                    <li
+                      key={entry.id}
+                      style={{
+                        border: '1px solid rgba(148,163,184,0.45)',
+                        borderRadius: 16,
+                        padding: 16,
+                        background: 'rgba(248,250,252,0.95)',
+                        display: 'grid',
+                        gap: 6,
+                      }}
+                    >
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12 }}>
+                        <strong style={{ fontSize: 15, color: '#0f172a' }}>+{entry.xp.toLocaleString('de-DE')} XP</strong>
+                        <span style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(entry.timestamp)}</span>
+                      </div>
+                      <div style={{ fontSize: 14, color: '#0f172a' }}>{entry.questName}</div>
+                      {entry.note && <div style={{ fontSize: 12, color: '#475569' }}>{entry.note}</div>}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </details>
         </div>
       </div>
     </div>

--- a/classquest/src/ui/shortcut/events.ts
+++ b/classquest/src/ui/shortcut/events.ts
@@ -8,3 +8,4 @@ export const EVENT_REQUEST_UNDO = 'cq:request-undo';
 export const EVENT_EXPORT_DATA = 'cq:export-data';
 export const EVENT_IMPORT_DATA = 'cq:import-data';
 export const EVENT_OPEN_SEASON_RESET = 'cq:open-season-reset';
+export const EVENT_NAVIGATE_TAB = 'cq:navigate-tab';

--- a/classquest/src/ui/student/getNextStudentId.ts
+++ b/classquest/src/ui/student/getNextStudentId.ts
@@ -1,0 +1,32 @@
+import type { Student } from '~/types/models';
+
+export type StudentNavigationDirection = 'forward' | 'backward';
+
+export function getNextStudentId(
+  currentId: string | null | undefined,
+  direction: StudentNavigationDirection,
+  students: Array<Pick<Student, 'id'>>,
+): string | null {
+  if (!Array.isArray(students) || students.length === 0) {
+    return null;
+  }
+
+  const safeCurrentId = typeof currentId === 'string' ? currentId : null;
+  const currentIndex = safeCurrentId
+    ? students.findIndex((student) => student.id === safeCurrentId)
+    : -1;
+
+  if (currentIndex === -1) {
+    return direction === 'backward' ? students[students.length - 1]?.id ?? null : students[0]?.id ?? null;
+  }
+
+  if (direction === 'forward') {
+    const nextIndex = (currentIndex + 1) % students.length;
+    return students[nextIndex]?.id ?? null;
+  }
+
+  const previousIndex = (currentIndex - 1 + students.length) % students.length;
+  return students[previousIndex]?.id ?? null;
+}
+
+export default getNextStudentId;

--- a/classquest/src/ui/student/navigate.ts
+++ b/classquest/src/ui/student/navigate.ts
@@ -1,0 +1,16 @@
+import { EVENT_FOCUS_STUDENT, EVENT_NAVIGATE_TAB } from '~/ui/shortcut/events';
+
+type NavigateDetail = { tab: 'award'; studentId?: string };
+
+export function navigateToAwardScreen(studentId?: string | null) {
+  const detail: NavigateDetail = { tab: 'award' };
+  if (studentId) {
+    detail.studentId = studentId;
+  }
+  window.dispatchEvent(new CustomEvent(EVENT_NAVIGATE_TAB, { detail }));
+  if (studentId) {
+    window.dispatchEvent(new CustomEvent(EVENT_FOCUS_STUDENT, { detail: studentId }));
+  }
+}
+
+export default navigateToAwardScreen;

--- a/classquest/src/ui/utils/isTextInputLike.ts
+++ b/classquest/src/ui/utils/isTextInputLike.ts
@@ -1,0 +1,18 @@
+export function isTextInputLike(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  const tag = target.tagName.toLowerCase();
+  if (tag === 'input' || tag === 'textarea' || tag === 'select') {
+    return true;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  const role = target.getAttribute('role');
+  return role === 'textbox' || role === 'combobox';
+}
+
+export function shouldIgnoreNavigation(event: KeyboardEvent): boolean {
+  return isTextInputLike(event.target);
+}


### PR DESCRIPTION
## Summary
- add a new StudentProfileCardV2 with hero avatar layout, XP stats, and trophy grid
- provide supporting UI pieces including AvatarZoomModal, TrophyGrid, and keyboard navigation utilities
- update overview/detail/manage screens and docs to integrate the redesign and cover with tests

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d00cfeb7e8832caf35cd8a23621171