### PR TITLE
Add weekly snapshot presentation view

### DIFF
--- a/classquest/src/core/show/avatarStageUrl.ts
+++ b/classquest/src/core/show/avatarStageUrl.ts
@@ -1,0 +1,57 @@
+import type { AppState, Student } from '~/types/models';
+import { getObjectURL } from '~/services/blobStore';
+
+function sanitizeStageKeys(pack?: Student['avatarPack']): (string | null)[] {
+  const raw = Array.isArray(pack?.stageKeys) ? pack?.stageKeys ?? [] : [];
+  return raw.map((value) => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+    return null;
+  });
+}
+
+export async function getAvatarStageUrl(
+  state: AppState,
+  student: Student,
+  stage: number,
+): Promise<string | null> {
+  if (student.avatarMode !== 'imagePack') {
+    return null;
+  }
+  const keys = sanitizeStageKeys(student.avatarPack);
+  if (!keys.length) {
+    return null;
+  }
+  const clamped = Math.max(0, Math.min(stage, keys.length - 1));
+  let key = keys[clamped];
+  if (!key) {
+    for (let index = clamped; index >= 0; index -= 1) {
+      const fallback = keys[index];
+      if (fallback) {
+        key = fallback;
+        break;
+      }
+    }
+  }
+  if (!key) {
+    for (let index = keys.length - 1; index >= 0; index -= 1) {
+      const fallback = keys[index];
+      if (fallback) {
+        key = fallback;
+        break;
+      }
+    }
+  }
+  if (!key) {
+    return null;
+  }
+  try {
+    const url = await getObjectURL(key);
+    return url ?? null;
+  } catch (error) {
+    console.warn('Unable to load avatar stage object URL', error);
+    return null;
+  }
+}

--- a/classquest/src/core/show/weekly.ts
+++ b/classquest/src/core/show/weekly.ts
@@ -1,0 +1,123 @@
+import { resolveAvatarStageIndex, sanitizeAvatarStageThresholds } from '~/core/avatarStages';
+import { levelFromXP } from '~/core/xp';
+import type { AppState } from '~/types/models';
+import type { WeeklySnapshot } from '~/services/weeklyStorage';
+
+export type WeeklyDelta = {
+  studentId: string;
+  alias: string;
+  xpStart: number;
+  xpEnd: number;
+  levelStart: number;
+  levelEnd: number;
+  avatarStageStart: number;
+  avatarStageEnd: number;
+  newBadges: Array<{ id: string; name: string; iconKey?: string | null; awardedAt: string }>;
+};
+
+function startOfWeek(reference = new Date()): Date {
+  const base = new Date(reference);
+  base.setHours(0, 0, 0, 0);
+  const day = base.getDay();
+  const diff = day === 0 ? 6 : day - 1;
+  base.setDate(base.getDate() - diff);
+  return base;
+}
+
+function resolveFromDate(fromISO?: string): Date {
+  if (!fromISO) {
+    return startOfWeek();
+  }
+  const parsed = new Date(fromISO);
+  if (Number.isNaN(parsed.getTime())) {
+    return startOfWeek();
+  }
+  return parsed;
+}
+
+export function computeWeeklyDeltas(state: AppState, fromISO?: string): WeeklyDelta[] {
+  const fromDate = resolveFromDate(fromISO);
+  const fromTime = fromDate.getTime();
+  const xpPerLevel = state.settings?.xpPerLevel ?? 100;
+  const thresholds = sanitizeAvatarStageThresholds(state.settings?.avatarStageThresholds);
+  const xpByStudent = new Map<string, number>();
+
+  for (const entry of state.logs ?? []) {
+    const timestamp = Number(entry.timestamp);
+    if (!Number.isFinite(timestamp) || timestamp < fromTime) {
+      continue;
+    }
+    const current = xpByStudent.get(entry.studentId) ?? 0;
+    xpByStudent.set(entry.studentId, current + Math.max(0, entry.xp ?? 0));
+  }
+
+  return (state.students ?? []).map((student) => {
+    const xpGain = xpByStudent.get(student.id) ?? 0;
+    const xpEnd = Math.max(0, student.xp ?? 0);
+    const xpStart = Math.max(0, xpEnd - xpGain);
+    const levelEnd = Math.max(1, student.level ?? levelFromXP(xpEnd, xpPerLevel));
+    const levelStart = Math.max(1, levelFromXP(xpStart, xpPerLevel));
+    const avatarStageStart = resolveAvatarStageIndex(levelStart, thresholds);
+    const avatarStageEnd = resolveAvatarStageIndex(levelEnd, thresholds);
+    const newBadges = (student.badges ?? [])
+      .filter((badge) => {
+        const awardedTime = Date.parse(badge.awardedAt);
+        return Number.isFinite(awardedTime) && awardedTime >= fromTime;
+      })
+      .map((badge) => ({
+        id: badge.id,
+        name: badge.name,
+        iconKey: badge.iconKey ?? null,
+        awardedAt: badge.awardedAt,
+      }));
+
+    return {
+      studentId: student.id,
+      alias: student.alias,
+      xpStart,
+      xpEnd,
+      levelStart,
+      levelEnd,
+      avatarStageStart,
+      avatarStageEnd,
+      newBadges,
+    } satisfies WeeklyDelta;
+  });
+}
+
+export function computeDeltasFromSnapshot(state: AppState, snapshot: WeeklySnapshot): WeeklyDelta[] {
+  const xpPerLevel = state.settings?.xpPerLevel ?? 100;
+  const thresholds = sanitizeAvatarStageThresholds(state.settings?.avatarStageThresholds);
+  const baseline = new Map(snapshot.students.map((entry) => [entry.id, entry]));
+
+  return (state.students ?? []).map((student) => {
+    const base = baseline.get(student.id);
+    const xpEnd = Math.max(0, student.xp ?? 0);
+    const xpStart = Math.max(0, base?.xp ?? 0);
+    const levelEnd = Math.max(1, student.level ?? levelFromXP(xpEnd, xpPerLevel));
+    const levelStart = Math.max(1, base?.level ?? levelFromXP(xpStart, xpPerLevel));
+    const avatarStageEnd = resolveAvatarStageIndex(levelEnd, thresholds);
+    const avatarStageStart = base?.stage ?? resolveAvatarStageIndex(levelStart, thresholds);
+    const existingBadgeIds = new Set(base?.badgeIds ?? []);
+    const newBadges = (student.badges ?? [])
+      .filter((badge) => !existingBadgeIds.has(badge.id))
+      .map((badge) => ({
+        id: badge.id,
+        name: badge.name,
+        iconKey: badge.iconKey ?? null,
+        awardedAt: badge.awardedAt,
+      }));
+
+    return {
+      studentId: student.id,
+      alias: student.alias,
+      xpStart,
+      xpEnd,
+      levelStart,
+      levelEnd,
+      avatarStageStart,
+      avatarStageEnd,
+      newBadges,
+    } satisfies WeeklyDelta;
+  });
+}

--- a/classquest/src/main.tsx
+++ b/classquest/src/main.tsx
@@ -5,8 +5,16 @@ import './index.css';
 import { AppProvider } from './app/AppContext';
 import { FeedbackProvider } from './ui/feedback/FeedbackProvider';
 import { KeyScopeProvider } from './ui/shortcut/KeyScope';
+import WeeklyShowPlayer from './ui/show/WeeklyShowPlayer';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById('root');
+if (!rootElement) {
+  throw new Error('Root element not found');
+}
+
+const isShowRoute = typeof window !== 'undefined' && window.location.pathname.startsWith('/show');
+
+const appTree = (
   <React.StrictMode>
     <AppProvider>
       <FeedbackProvider>
@@ -15,5 +23,17 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         </KeyScopeProvider>
       </FeedbackProvider>
     </AppProvider>
-  </React.StrictMode>,
+  </React.StrictMode>
 );
+
+const showTree = (
+  <React.StrictMode>
+    <AppProvider>
+      <FeedbackProvider>
+        <WeeklyShowPlayer />
+      </FeedbackProvider>
+    </AppProvider>
+  </React.StrictMode>
+);
+
+ReactDOM.createRoot(rootElement).render(isShowRoute ? showTree : appTree);

--- a/classquest/src/services/weeklyStorage.ts
+++ b/classquest/src/services/weeklyStorage.ts
@@ -1,0 +1,68 @@
+export type WeeklySnapshot = {
+  id: string;
+  label: string;
+  createdAt: string;
+  students: Array<{
+    id: string;
+    alias: string;
+    xp: number;
+    level: number;
+    stage: number;
+    badgeIds: string[];
+  }>;
+};
+
+const STORAGE_KEY = 'weekly:snapshots:v1';
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn('Weekly snapshot storage unavailable', error);
+    return null;
+  }
+}
+
+export function listSnapshots(): WeeklySnapshot[] {
+  const storage = getStorage();
+  if (!storage) {
+    return [];
+  }
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((entry): entry is WeeklySnapshot => {
+      return entry && typeof entry.id === 'string' && Array.isArray(entry.students);
+    });
+  } catch (error) {
+    console.warn('Failed to read weekly snapshots', error);
+    return [];
+  }
+}
+
+export function saveSnapshots(entries: WeeklySnapshot[]): void {
+  const storage = getStorage();
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (error) {
+    console.warn('Failed to persist weekly snapshots', error);
+  }
+}
+
+export function addSnapshot(snapshot: WeeklySnapshot): void {
+  const existing = listSnapshots().filter((entry) => entry.id !== snapshot.id);
+  existing.unshift(snapshot);
+  saveSnapshots(existing.slice(0, 24));
+}

--- a/classquest/src/ui/manage/ManageSnapshots.tsx
+++ b/classquest/src/ui/manage/ManageSnapshots.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import { resolveAvatarStageIndex, sanitizeAvatarStageThresholds } from '~/core/avatarStages';
+import { levelFromXP } from '~/core/xp';
+import { addSnapshot, listSnapshots, type WeeklySnapshot } from '~/services/weeklyStorage';
+
+function getWeekLabel(date: Date): string {
+  const utcDate = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = utcDate.getUTCDay() === 0 ? 7 : utcDate.getUTCDay();
+  utcDate.setUTCDate(utcDate.getUTCDate() + 4 - dayNumber);
+  const yearStart = new Date(Date.UTC(utcDate.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(((utcDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+  return `KW ${week} (${date.toISOString().slice(0, 10)})`;
+}
+
+function formatTimestamp(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString('de-DE');
+}
+
+export default function ManageSnapshots() {
+  const { state } = useApp();
+  const [snapshots, setSnapshots] = React.useState<WeeklySnapshot[]>(() => listSnapshots());
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return () => undefined;
+    }
+    const handleStorage = () => setSnapshots(listSnapshots());
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const createSnapshot = React.useCallback(() => {
+    const now = new Date();
+    const xpPerLevel = state.settings?.xpPerLevel ?? 100;
+    const thresholds = sanitizeAvatarStageThresholds(state.settings?.avatarStageThresholds);
+    const snapshot: WeeklySnapshot = {
+      id: now.toISOString(),
+      label: getWeekLabel(now),
+      createdAt: now.toISOString(),
+      students: (state.students ?? []).map((student) => {
+        const xp = Math.max(0, student.xp ?? 0);
+        const level = Math.max(1, student.level ?? levelFromXP(xp, xpPerLevel));
+        const stage = resolveAvatarStageIndex(level, thresholds);
+        return {
+          id: student.id,
+          alias: student.alias,
+          xp,
+          level,
+          stage,
+          badgeIds: (student.badges ?? []).map((badge) => badge.id),
+        };
+      }),
+    };
+    addSnapshot(snapshot);
+    setSnapshots(listSnapshots());
+  }, [state]);
+
+  return (
+    <div
+      style={{
+        padding: 16,
+        borderRadius: 16,
+        border: '1px solid #cbd5f5',
+        background: '#f8fafc',
+        display: 'grid',
+        gap: 12,
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          onClick={createSnapshot}
+          style={{
+            padding: '10px 16px',
+            borderRadius: 999,
+            border: '1px solid #94a3b8',
+            background: '#0f172a',
+            color: '#f8fafc',
+            fontWeight: 600,
+          }}
+        >
+          Snapshot speichern
+        </button>
+        <a
+          href="/show"
+          target="_blank"
+          rel="noreferrer"
+          style={{
+            padding: '10px 16px',
+            borderRadius: 999,
+            border: '1px solid #94a3b8',
+            background: '#e2e8f0',
+            color: '#0f172a',
+            textDecoration: 'none',
+            fontWeight: 600,
+          }}
+        >
+          Weekly-Show öffnen
+        </a>
+      </div>
+      <p style={{ margin: 0, fontSize: 13, color: '#475569' }}>
+        Snapshots werden im Browser gespeichert und dienen als Basis für die Weekly-Show.
+      </p>
+      {snapshots.length === 0 ? (
+        <p style={{ margin: 0, fontStyle: 'italic', color: '#64748b' }}>Noch keine Snapshots vorhanden.</p>
+      ) : (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'grid', gap: 8 }}>
+          {snapshots.map((snapshot) => (
+            <li
+              key={snapshot.id}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 12px',
+                borderRadius: 12,
+                background: '#fff',
+                border: '1px solid #e2e8f0',
+              }}
+            >
+              <div style={{ fontWeight: 600 }}>{snapshot.label}</div>
+              <div style={{ fontSize: 12, color: '#64748b' }}>{formatTimestamp(snapshot.createdAt)}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/ManageScreen.tsx
+++ b/classquest/src/ui/screens/ManageScreen.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_SETTINGS } from '~/core/config';
 import StudentDetailScreen from '~/ui/screens/StudentDetailScreen';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import { CollapsibleSection, useCollapsibleState } from '~/ui/components/CollapsibleSection';
+import ManageSnapshots from '~/ui/manage/ManageSnapshots';
 
 const questTypes: QuestType[] = ['daily', 'repeatable', 'oneoff'];
 
@@ -890,6 +891,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
     },
     [dispatch, stage1Threshold, stage2Threshold],
   );
+  const weeklyCollapse = useCollapsibleState('manage-weekly', true);
   const studentsCollapse = useCollapsibleState('manage-students', true);
   const classGoalsCollapse = useCollapsibleState('manage-class-goals', true);
   const categoriesCollapse = useCollapsibleState('manage-categories', true);
@@ -903,6 +905,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
   const collapsibleSections = useMemo(
     () =>
       [
+        weeklyCollapse,
         studentsCollapse,
         classGoalsCollapse,
         categoriesCollapse,
@@ -914,6 +917,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
         backupCollapse,
       ] as const,
     [
+      weeklyCollapse,
       studentsCollapse,
       classGoalsCollapse,
       categoriesCollapse,
@@ -1579,6 +1583,13 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
           {allSectionsOpen ? 'Alle Menüs zuklappen' : 'Alle Menüs aufklappen'}
         </button>
       </div>
+      <CollapsibleSection id="manage-weekly" title="Weekly-Show & Snapshots" state={weeklyCollapse}>
+        <p style={{ marginTop: 0, marginBottom: 12, fontSize: 14, color: '#475569' }}>
+          Sichere den Wochenstand und starte die Präsentation der Fortschritte. Snapshots werden lokal gespeichert.
+        </p>
+        <ManageSnapshots />
+      </CollapsibleSection>
+
       <CollapsibleSection id="manage-students" title="Schüler verwalten" state={studentsCollapse}>
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', marginBottom: 12 }}>
           <input

--- a/classquest/src/ui/show/WeeklyShowPlayer.tsx
+++ b/classquest/src/ui/show/WeeklyShowPlayer.tsx
@@ -1,0 +1,341 @@
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import WeeklyShowSlide from '~/ui/show/WeeklyShowSlide';
+import { computeDeltasFromSnapshot, computeWeeklyDeltas, type WeeklyDelta } from '~/core/show/weekly';
+import { listSnapshots, type WeeklySnapshot } from '~/services/weeklyStorage';
+
+function formatDateLabel(snapshot: WeeklySnapshot): string {
+  const created = new Date(snapshot.createdAt);
+  return `${snapshot.label} – ${created.toLocaleString('de-DE')}`;
+}
+
+function shuffle(values: WeeklyDelta[]): WeeklyDelta[] {
+  const copy = [...values];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(Math.random() * (index + 1));
+    const tmp = copy[index];
+    copy[index] = copy[swapIndex];
+    copy[swapIndex] = tmp;
+  }
+  return copy;
+}
+
+type Order = 'alpha' | 'delta' | 'random';
+
+const BACKGROUND_STYLE: React.CSSProperties = {
+  minHeight: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  background: 'linear-gradient(135deg, #0f172a 0%, #312e81 60%, #0f172a 100%)',
+  color: '#e2e8f0',
+};
+
+export default function WeeklyShowPlayer() {
+  const { state } = useApp();
+  const [order, setOrder] = React.useState<Order>('delta');
+  const [onlyChanged, setOnlyChanged] = React.useState(true);
+  const [autoPlay, setAutoPlay] = React.useState(true);
+  const [durationSeconds, setDurationSeconds] = React.useState(12);
+  const [currentIndex, setCurrentIndex] = React.useState(0);
+  const [fromInput, setFromInput] = React.useState('');
+  const [fromISO, setFromISO] = React.useState<string | undefined>(undefined);
+  const [useSnapshot, setUseSnapshot] = React.useState(true);
+  const [snapshots, setSnapshots] = React.useState<WeeklySnapshot[]>(() => listSnapshots());
+  const [snapshotId, setSnapshotId] = React.useState<string | undefined>(() => listSnapshots()[0]?.id);
+
+  React.useEffect(() => {
+    const handleStorage = () => {
+      setSnapshots(listSnapshots());
+    };
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', handleStorage);
+      return () => window.removeEventListener('storage', handleStorage);
+    }
+    return () => undefined;
+  }, []);
+
+  React.useEffect(() => {
+    if (snapshots.length === 0 && useSnapshot) {
+      setUseSnapshot(false);
+    }
+  }, [snapshots.length, useSnapshot]);
+
+  React.useEffect(() => {
+    if (snapshotId && snapshots.some((entry) => entry.id === snapshotId)) {
+      return;
+    }
+    setSnapshotId(snapshots[0]?.id);
+  }, [snapshotId, snapshots]);
+
+  const deltas = React.useMemo(() => {
+    let result: WeeklyDelta[] = [];
+    if (useSnapshot) {
+      const snapshot = snapshots.find((entry) => entry.id === snapshotId);
+      if (snapshot) {
+        result = computeDeltasFromSnapshot(state, snapshot);
+      } else {
+        result = computeWeeklyDeltas(state, fromISO);
+      }
+    } else {
+      result = computeWeeklyDeltas(state, fromISO);
+    }
+
+    if (onlyChanged) {
+      result = result.filter((delta) => {
+        const xpGain = delta.xpEnd - delta.xpStart;
+        const levelGain = delta.levelEnd - delta.levelStart;
+        return xpGain > 0 || levelGain > 0 || delta.newBadges.length > 0;
+      });
+    }
+
+    switch (order) {
+      case 'alpha':
+        result = [...result].sort((a, b) => a.alias.localeCompare(b.alias, 'de'));
+        break;
+      case 'delta':
+        result = [...result].sort((a, b) => {
+          const gainA = a.xpEnd - a.xpStart;
+          const gainB = b.xpEnd - b.xpStart;
+          return gainB - gainA;
+        });
+        break;
+      case 'random':
+        result = shuffle(result);
+        break;
+      default:
+        break;
+    }
+    return result;
+  }, [state, fromISO, order, onlyChanged, useSnapshot, snapshotId, snapshots]);
+
+  React.useEffect(() => {
+    setCurrentIndex(0);
+  }, [order, onlyChanged, fromISO, useSnapshot, snapshotId, snapshots]);
+
+  React.useEffect(() => {
+    if (!autoPlay || deltas.length === 0) {
+      return;
+    }
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      setCurrentIndex((previous) => {
+        const next = previous + 1;
+        return next >= deltas.length ? 0 : next;
+      });
+    }, Math.max(4000, durationSeconds * 1000));
+    return () => window.clearTimeout(timer);
+  }, [autoPlay, currentIndex, deltas.length, durationSeconds]);
+
+  const current = deltas[currentIndex];
+  const durationMs = Math.max(4000, durationSeconds * 1000);
+
+  const handleManualAdvance = (step: number) => {
+    if (deltas.length === 0) {
+      return;
+    }
+    setCurrentIndex((previous) => {
+      const next = (previous + step + deltas.length) % deltas.length;
+      return next;
+    });
+  };
+
+  const headerControls = (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 12,
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+        <label style={{ display: 'flex', flexDirection: 'column', fontSize: 13 }}>
+          Baseline: Snapshot
+          <span>
+            <input
+              type="checkbox"
+              checked={useSnapshot}
+              onChange={(event) => setUseSnapshot(event.target.checked)}
+              style={{ marginRight: 6 }}
+            />
+            {snapshots.length === 0 && <span style={{ marginLeft: 4 }}>Keine Snapshots verfügbar</span>}
+          </span>
+        </label>
+        {useSnapshot ? (
+          <select
+            value={snapshotId}
+            onChange={(event) => setSnapshotId(event.target.value || undefined)}
+            style={{ padding: '6px 10px', borderRadius: 10, border: '1px solid rgba(148,163,184,0.4)' }}
+          >
+            {snapshots.map((snapshot) => (
+              <option value={snapshot.id} key={snapshot.id}>
+                {formatDateLabel(snapshot)}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <label style={{ display: 'flex', flexDirection: 'column', fontSize: 13 }}>
+            Startzeit (optional)
+            <input
+              type="datetime-local"
+              value={fromInput}
+              onChange={(event) => {
+                const value = event.target.value;
+                setFromInput(value);
+                setFromISO(value ? new Date(value).toISOString() : undefined);
+              }}
+              style={{ marginTop: 4, padding: '6px 10px', borderRadius: 10, border: '1px solid rgba(148,163,184,0.4)' }}
+            />
+          </label>
+        )}
+        <label style={{ fontSize: 13 }}>
+          Reihenfolge
+          <select
+            value={order}
+            onChange={(event) => setOrder(event.target.value as Order)}
+            style={{ marginLeft: 6, padding: '6px 10px', borderRadius: 10, border: '1px solid rgba(148,163,184,0.4)' }}
+          >
+            <option value="alpha">Alphabetisch</option>
+            <option value="delta">XP-Delta</option>
+            <option value="random">Zufällig</option>
+          </select>
+        </label>
+        <label style={{ display: 'flex', alignItems: 'center', fontSize: 13 }}>
+          <input
+            type="checkbox"
+            checked={onlyChanged}
+            onChange={(event) => setOnlyChanged(event.target.checked)}
+            style={{ marginRight: 6 }}
+          />
+          Nur Veränderungen
+        </label>
+      </div>
+      <button
+        type="button"
+        onClick={() => setSnapshots(listSnapshots())}
+        style={{ padding: '8px 14px', borderRadius: 999, border: '1px solid rgba(148,163,184,0.4)', background: 'rgba(15,23,42,0.35)', color: '#e2e8f0' }}
+      >
+        Snapshots aktualisieren
+      </button>
+    </div>
+  );
+
+  const footerControls = (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: 12,
+        alignItems: 'center',
+        justifyContent: 'space-between',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+        <button
+          type="button"
+          onClick={() => handleManualAdvance(-1)}
+          disabled={deltas.length === 0}
+          style={{
+            padding: '8px 16px',
+            borderRadius: 999,
+            border: '1px solid rgba(148,163,184,0.4)',
+            background: 'rgba(15,23,42,0.35)',
+            color: '#e2e8f0',
+            cursor: deltas.length === 0 ? 'not-allowed' : 'pointer',
+            opacity: deltas.length === 0 ? 0.6 : 1,
+          }}
+        >
+          Zurück
+        </button>
+        <button
+          type="button"
+          onClick={() => setAutoPlay((value) => !value)}
+          style={{
+            padding: '8px 16px',
+            borderRadius: 999,
+            border: '1px solid rgba(148,163,184,0.4)',
+            background: autoPlay ? '#4ade80' : 'rgba(15,23,42,0.35)',
+            color: autoPlay ? '#0f172a' : '#e2e8f0',
+            fontWeight: 600,
+          }}
+        >
+          {autoPlay ? 'Pause' : 'Abspielen'}
+        </button>
+        <button
+          type="button"
+          onClick={() => handleManualAdvance(1)}
+          disabled={deltas.length === 0}
+          style={{
+            padding: '8px 16px',
+            borderRadius: 999,
+            border: '1px solid rgba(148,163,184,0.4)',
+            background: 'rgba(15,23,42,0.35)',
+            color: '#e2e8f0',
+            cursor: deltas.length === 0 ? 'not-allowed' : 'pointer',
+            opacity: deltas.length === 0 ? 0.6 : 1,
+          }}
+        >
+          Weiter
+        </button>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 13 }}>
+          Dauer (Sek.)
+          <input
+            type="number"
+            min={4}
+            max={30}
+            value={durationSeconds}
+            onChange={(event) => {
+              const value = Number.parseInt(event.target.value, 10);
+              if (Number.isFinite(value)) {
+                setDurationSeconds(Math.min(30, Math.max(4, value)));
+              }
+            }}
+            style={{ width: 72, padding: '6px 10px', borderRadius: 10, border: '1px solid rgba(148,163,184,0.4)' }}
+          />
+        </label>
+      </div>
+      <div style={{ fontSize: 14, opacity: 0.85 }}>
+        {deltas.length === 0 ? 'Keine Einträge' : `Slide ${currentIndex + 1} von ${deltas.length}`}
+      </div>
+    </div>
+  );
+
+  return (
+    <div style={BACKGROUND_STYLE}>
+      <header style={{ padding: '20px 24px', borderBottom: '1px solid rgba(148,163,184,0.3)' }}>{headerControls}</header>
+      <main
+        style={{
+          flex: '1 1 auto',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '32px 24px',
+        }}
+      >
+        {current ? (
+          <WeeklyShowSlide key={current.studentId} data={current} durationMs={durationMs} />
+        ) : (
+          <div
+            style={{
+              padding: 36,
+              borderRadius: 24,
+              background: 'rgba(15,23,42,0.7)',
+              border: '1px solid rgba(148,163,184,0.3)',
+              maxWidth: 520,
+              textAlign: 'center',
+            }}
+          >
+            <h2 style={{ marginTop: 0 }}>Keine Daten für diese Auswahl</h2>
+            <p style={{ marginBottom: 0 }}>
+              Lege einen Snapshot an oder wähle einen anderen Zeitraum, um Fortschritte zu sehen.
+            </p>
+          </div>
+        )}
+      </main>
+      <footer style={{ padding: '20px 24px', borderTop: '1px solid rgba(148,163,184,0.3)' }}>{footerControls}</footer>
+    </div>
+  );
+}

--- a/classquest/src/ui/show/WeeklyShowSlide.tsx
+++ b/classquest/src/ui/show/WeeklyShowSlide.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import { AvatarView } from '~/ui/avatar/AvatarView';
+import { BadgeIcon } from '~/ui/components/BadgeIcon';
+import { getAvatarStageUrl } from '~/core/show/avatarStageUrl';
+import type { WeeklyDelta } from '~/core/show/weekly';
+
+const AVATAR_SIZE = 220;
+
+type WeeklyShowSlideProps = {
+  data: WeeklyDelta;
+  durationMs?: number;
+};
+
+function formatNumber(value: number): string {
+  return value.toLocaleString('de-DE');
+}
+
+export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShowSlideProps) {
+  const { state } = useApp();
+  const student = state.students.find((entry) => entry.id === data.studentId);
+  const [phase, setPhase] = React.useState<'intro' | 'xp' | 'level' | 'badges' | 'done'>('intro');
+  const [previousStageUrl, setPreviousStageUrl] = React.useState<string | null>(null);
+  const [showCurrentStage, setShowCurrentStage] = React.useState(false);
+
+  React.useEffect(() => {
+    setPhase('intro');
+    const timers: number[] = [];
+    if (typeof window !== 'undefined') {
+      timers.push(window.setTimeout(() => setPhase('xp'), Math.min(2200, durationMs * 0.25)));
+      timers.push(window.setTimeout(() => setPhase('level'), Math.min(5200, durationMs * 0.48)));
+      timers.push(window.setTimeout(() => setPhase('badges'), Math.min(9200, durationMs * 0.76)));
+      timers.push(window.setTimeout(() => setPhase('done'), durationMs));
+    }
+    return () => {
+      timers.forEach((id) => {
+        if (typeof window !== 'undefined') {
+          window.clearTimeout(id);
+        }
+      });
+    };
+  }, [data.studentId, durationMs]);
+
+  React.useEffect(() => {
+    setShowCurrentStage(false);
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const timer = window.setTimeout(() => setShowCurrentStage(true), 120);
+    return () => window.clearTimeout(timer);
+  }, [data.studentId]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    if (!student || data.avatarStageEnd <= data.avatarStageStart) {
+      setPreviousStageUrl(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+    (async () => {
+      const url = await getAvatarStageUrl(state, student, data.avatarStageStart);
+      if (!cancelled) {
+        setPreviousStageUrl(url);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [student, state, data.avatarStageStart, data.avatarStageEnd]);
+
+  if (!student) {
+    return (
+      <div
+        style={{
+          background: 'rgba(15,23,42,0.75)',
+          padding: 32,
+          borderRadius: 24,
+          color: '#e2e8f0',
+          maxWidth: 720,
+          margin: '0 auto',
+          textAlign: 'center',
+        }}
+      >
+        <p style={{ margin: 0 }}>Schüler nicht gefunden.</p>
+      </div>
+    );
+  }
+
+  const xpGain = Math.max(0, data.xpEnd - data.xpStart);
+  const levelGain = Math.max(0, data.levelEnd - data.levelStart);
+  const evolved = data.avatarStageEnd > data.avatarStageStart;
+  const showBadges = data.newBadges.length > 0;
+
+  const badgeList = (
+    <div
+      style={{
+        display: 'grid',
+        gap: 12,
+        opacity: phase === 'badges' || phase === 'done' ? 1 : 0,
+        transform: phase === 'badges' || phase === 'done' ? 'translateY(0)' : 'translateY(12px)',
+        transition: 'opacity 0.5s ease, transform 0.5s ease',
+      }}
+    >
+      <h3 style={{ margin: 0, fontSize: 20 }}>Neue Badges</h3>
+      <ul
+        style={{
+          margin: 0,
+          padding: 0,
+          listStyle: 'none',
+          display: 'grid',
+          gap: 12,
+        }}
+      >
+        {data.newBadges.map((badge) => (
+          <li
+            key={badge.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 12,
+              padding: '8px 12px',
+              borderRadius: 12,
+              background: 'rgba(15,23,42,0.3)',
+            }}
+          >
+            <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={48} />
+            <div style={{ display: 'grid', gap: 4 }}>
+              <strong>{badge.name}</strong>
+              <span style={{ fontSize: 12, opacity: 0.8 }}>
+                Verliehen am {new Date(badge.awardedAt).toLocaleDateString('de-DE')}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+
+  const metricStyle: React.CSSProperties = {
+    padding: '16px 20px',
+    borderRadius: 16,
+    background: 'rgba(15,23,42,0.3)',
+    display: 'grid',
+    gap: 4,
+  };
+
+  return (
+    <div
+      style={{
+        width: '100%',
+        maxWidth: 960,
+        background: 'rgba(15,23,42,0.8)',
+        color: '#e2e8f0',
+        padding: 36,
+        borderRadius: 28,
+        boxShadow: '0 20px 60px rgba(15,23,42,0.45)',
+        display: 'grid',
+        gap: 24,
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gap: 24,
+          gridTemplateColumns: 'minmax(200px, 240px) 1fr',
+          alignItems: 'center',
+        }}
+      >
+        <div style={{ position: 'relative', justifySelf: 'center' }}>
+          {evolved && (
+            <div
+              aria-hidden
+              style={{
+                position: 'absolute',
+                top: -24,
+                left: -24,
+                right: -24,
+                bottom: -24,
+                borderRadius: AVATAR_SIZE,
+                background:
+                  'radial-gradient(circle at center, rgba(253,224,71,0.4), rgba(253,224,71,0) 70%)',
+                filter: 'blur(12px)',
+              }}
+            />
+          )}
+          <div
+            style={{
+              position: 'relative',
+              width: AVATAR_SIZE,
+              height: AVATAR_SIZE,
+            }}
+          >
+            {previousStageUrl && (
+              <img
+                src={previousStageUrl}
+                alt="Vorheriger Avatar"
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                  borderRadius: AVATAR_SIZE / 2,
+                  opacity: showCurrentStage ? 0 : 1,
+                  transition: 'opacity 0.6s ease',
+                }}
+              />
+            )}
+            <div
+              style={{
+                position: 'absolute',
+                inset: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                opacity: showCurrentStage ? 1 : 0,
+                transition: 'opacity 0.6s ease',
+              }}
+            >
+              <AvatarView student={student} size={AVATAR_SIZE} rounded="xl" />
+            </div>
+          </div>
+        </div>
+        <div style={{ display: 'grid', gap: 16 }}>
+          <div style={{ display: 'grid', gap: 4 }}>
+            <span style={{ fontSize: 14, letterSpacing: 1.2, textTransform: 'uppercase', opacity: 0.7 }}>
+              Fortschritt der Woche
+            </span>
+            <h2 style={{ margin: 0, fontSize: 36 }}>{student.alias}</h2>
+          </div>
+          <div style={{ display: 'grid', gap: 12 }}>
+            <div
+              style={{
+                ...metricStyle,
+                opacity: phase === 'intro' ? 0 : 1,
+                transform: phase === 'intro' ? 'translateY(12px)' : 'translateY(0)',
+                transition: 'opacity 0.5s ease, transform 0.5s ease',
+              }}
+            >
+              <span style={{ fontSize: 14, opacity: 0.75 }}>XP</span>
+              <strong style={{ fontSize: 28 }}>
+                {xpGain > 0 ? `+${formatNumber(xpGain)} XP` : 'Keine neuen XP'}
+              </strong>
+              <span style={{ fontSize: 14, opacity: 0.75 }}>
+                {formatNumber(data.xpStart)} → {formatNumber(data.xpEnd)}
+              </span>
+            </div>
+            <div
+              style={{
+                ...metricStyle,
+                opacity: phase === 'level' || phase === 'badges' || phase === 'done' ? 1 : 0,
+                transform:
+                  phase === 'level' || phase === 'badges' || phase === 'done'
+                    ? 'translateY(0)'
+                    : 'translateY(12px)',
+                transition: 'opacity 0.5s ease, transform 0.5s ease',
+              }}
+            >
+              <span style={{ fontSize: 14, opacity: 0.75 }}>Level</span>
+              <strong style={{ fontSize: 28 }}>
+                {data.levelStart} → {data.levelEnd}
+              </strong>
+              <span style={{ fontSize: 14, opacity: 0.75 }}>
+                {levelGain > 0 ? `+${levelGain} Level` : 'Stufe gehalten'}
+              </span>
+              {evolved && <span style={{ fontSize: 13, color: '#fde047' }}>Avatar ist eine Stufe aufgestiegen!</span>}
+            </div>
+          </div>
+        </div>
+      </div>
+      {showBadges ? badgeList : (
+        <div
+          style={{
+            ...metricStyle,
+            opacity: phase === 'badges' || phase === 'done' ? 1 : 0,
+            transform:
+              phase === 'badges' || phase === 'done' ? 'translateY(0)' : 'translateY(12px)',
+            transition: 'opacity 0.5s ease, transform 0.5s ease',
+            textAlign: 'center',
+          }}
+        >
+          <span style={{ fontSize: 14, opacity: 0.75 }}>Badges</span>
+          <strong style={{ fontSize: 24 }}>Keine neuen Badges</strong>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add localStorage-backed weekly snapshot service and delta calculations
- build weekly show player/slide UI with avatar stage transitions
- expose snapshot management in Manage screen and route /show entry point

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d014757300832c990c838057cabf22