### PR TITLE
Add evolution animation sequence for weekly show

### DIFF
--- a/classquest/src/ui/show/EvolutionSequence.tsx
+++ b/classquest/src/ui/show/EvolutionSequence.tsx
@@ -1,0 +1,265 @@
+import * as React from 'react';
+import { useApp } from '~/app/AppContext';
+import { AvatarView } from '~/ui/avatar/AvatarView';
+import type { Student } from '~/types/models';
+import { getAvatarStageUrl } from '~/core/show/avatarStageUrl';
+
+type EvolutionPhase = 'preload' | 'shake' | 'flash' | 'reveal' | 'hold' | 'done';
+
+type EvolutionSequenceProps = {
+  student: Student;
+  fromStage: number;
+  toStage: number;
+  size?: number;
+  totalMs?: number;
+  onDone?: () => void;
+};
+
+/**
+ * Pokémon-style evolution moment:
+ * - shows previous avatar (center)
+ * - brief shake (0.6s)
+ * - white flash (0.25s)
+ * - crossfade into new avatar with soft glow (0.8s)
+ * - hold final for the remainder
+ *
+ * Total default ~2.2s, configurable via props.
+ */
+export default function EvolutionSequence({
+  student,
+  fromStage,
+  toStage,
+  size = 220,
+  totalMs = 2200,
+  onDone,
+}: EvolutionSequenceProps) {
+  const { state } = useApp();
+  const [previousUrl, setPreviousUrl] = React.useState<string | null>(null);
+  const [nextUrl, setNextUrl] = React.useState<string | null>(null);
+  const [phase, setPhase] = React.useState<EvolutionPhase>('preload');
+  const [fallback, setFallback] = React.useState(false);
+  const stateRef = React.useRef(state);
+  const lastRequestedSignatureRef = React.useRef<string | null>(null);
+  const lastCompletedSignatureRef = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const rawStageKeys = student.avatarPack?.stageKeys;
+    const packStageKeys = Array.isArray(rawStageKeys) ? rawStageKeys : [];
+    const packKeys = packStageKeys.map((value) => value ?? '').join('|');
+    const signature = `${student.id}:${student.avatarMode}:${fromStage}:${toStage}:${packKeys}`;
+
+    if (lastCompletedSignatureRef.current === signature) {
+      return;
+    }
+
+    lastRequestedSignatureRef.current = signature;
+    setFallback(false);
+    setPreviousUrl(null);
+    setNextUrl(null);
+    setPhase('preload');
+
+    (async () => {
+      const [prev, next] = await Promise.all([
+        getAvatarStageUrl(stateRef.current, student, fromStage),
+        getAvatarStageUrl(stateRef.current, student, toStage),
+      ]);
+
+      if (cancelled || lastRequestedSignatureRef.current !== signature) {
+        return;
+      }
+
+      if (!prev || !next) {
+        lastCompletedSignatureRef.current = signature;
+        setFallback(true);
+        setPhase('done');
+        onDone?.();
+        return;
+      }
+
+      lastCompletedSignatureRef.current = signature;
+      setPreviousUrl(prev);
+      setNextUrl(next);
+      setPhase('shake');
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [student, fromStage, toStage, onDone]);
+
+  React.useEffect(() => {
+    if (phase === 'preload' || fallback) {
+      return;
+    }
+
+    if (typeof window === 'undefined') {
+      if (phase !== 'done') {
+        setPhase('done');
+        onDone?.();
+      }
+      return;
+    }
+
+    const total = Math.max(0, totalMs);
+    const shakeDuration = Math.round(total * 0.27);
+    const flashDuration = Math.round(total * 0.11);
+    const revealDuration = Math.round(total * 0.36);
+    const holdDuration = Math.max(0, total - (shakeDuration + flashDuration + revealDuration));
+    const timers: number[] = [];
+
+    if (phase === 'shake') {
+      timers.push(window.setTimeout(() => setPhase('flash'), shakeDuration));
+    } else if (phase === 'flash') {
+      timers.push(window.setTimeout(() => setPhase('reveal'), flashDuration));
+    } else if (phase === 'reveal') {
+      timers.push(window.setTimeout(() => setPhase('hold'), revealDuration));
+    } else if (phase === 'hold') {
+      timers.push(
+        window.setTimeout(() => {
+          setPhase('done');
+          onDone?.();
+        }, holdDuration),
+      );
+    }
+
+    return () => {
+      timers.forEach((id) => window.clearTimeout(id));
+    };
+  }, [phase, totalMs, onDone, fallback]);
+
+  const containerStyle: React.CSSProperties = {
+    position: 'relative',
+    width: size,
+    height: size,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  };
+
+  const borderRadius = Math.min(size / 2, 24);
+  const imageStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    width: size,
+    height: size,
+    objectFit: 'cover',
+    borderRadius,
+    transition: 'opacity 0.8s ease',
+  };
+
+  if (fallback) {
+    return (
+      <div style={containerStyle}>
+        <AvatarView student={student} size={size} rounded="xl" />
+      </div>
+    );
+  }
+
+  const revealActive = phase === 'reveal' || phase === 'hold' || phase === 'done';
+
+  return (
+    <div style={containerStyle}>
+      {phase !== 'preload' && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            top: -32,
+            right: -32,
+            bottom: -32,
+            left: -32,
+            borderRadius: size,
+            background: 'radial-gradient(40% 40% at 50% 50%, rgba(255,220,100,0.28), transparent 60%)',
+            opacity: 0.8,
+            filter: 'blur(36px)',
+            pointerEvents: 'none',
+          }}
+        />
+      )}
+
+      {previousUrl && (
+        <img
+          src={previousUrl}
+          alt="Vorheriger Avatar"
+          className={phase === 'shake' ? 'evo-shake' : undefined}
+          style={{
+            ...imageStyle,
+            opacity: revealActive ? 0 : 1,
+          }}
+        />
+      )}
+
+      <div
+        aria-hidden="true"
+        className={phase === 'flash' ? 'evo-flash' : undefined}
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          width: size,
+          height: size,
+          borderRadius,
+          backgroundColor: '#ffffff',
+          opacity: phase === 'flash' ? undefined : 0,
+          pointerEvents: 'none',
+        }}
+      />
+
+      {nextUrl && (
+        <img
+          src={nextUrl}
+          alt="Neuer Avatar"
+          className={revealActive ? 'evo-reveal' : undefined}
+          style={{
+            ...imageStyle,
+            opacity: revealActive ? 1 : 0,
+          }}
+        />
+      )}
+
+      <span className="sr-only" aria-live="polite">
+        {phase === 'reveal' && 'Avatar hat sich entwickelt.'}
+      </span>
+
+      <style>{`
+        @keyframes evoShake {
+          0%,100% { transform: translate(0,0) rotate(0deg); }
+          10% { transform: translate(-1px, 1px) rotate(-0.5deg); }
+          20% { transform: translate(1px, -1px) rotate(0.5deg); }
+          30% { transform: translate(-1px, 0) rotate(-0.4deg); }
+          40% { transform: translate(1px, 1px) rotate(0.4deg); }
+          50% { transform: translate(0, -1px) rotate(0deg); }
+          60% { transform: translate(1px, 0) rotate(0.4deg); }
+          70% { transform: translate(-1px, 1px) rotate(-0.4deg); }
+          80% { transform: translate(1px, -1px) rotate(0.5deg); }
+          90% { transform: translate(0, 1px) rotate(-0.5deg); }
+        }
+        .evo-shake {
+          animation: evoShake 600ms ease-in-out both;
+        }
+        @keyframes evoFlash {
+          0% { opacity: 0; }
+          20% { opacity: 1; }
+          100% { opacity: 0; }
+        }
+        .evo-flash {
+          animation: evoFlash 250ms ease-out both;
+        }
+        .evo-reveal {
+          transition: opacity 800ms ease;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/classquest/src/ui/show/WeeklyShowSlide.tsx
+++ b/classquest/src/ui/show/WeeklyShowSlide.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useApp } from '~/app/AppContext';
 import { AvatarView } from '~/ui/avatar/AvatarView';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
-import { getAvatarStageUrl } from '~/core/show/avatarStageUrl';
+import EvolutionSequence from '~/ui/show/EvolutionSequence';
 import type { WeeklyDelta } from '~/core/show/weekly';
 
 const AVATAR_SIZE = 220;
@@ -20,7 +20,6 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
   const { state } = useApp();
   const student = state.students.find((entry) => entry.id === data.studentId);
   const [phase, setPhase] = React.useState<'intro' | 'xp' | 'level' | 'badges' | 'done'>('intro');
-  const [previousStageUrl, setPreviousStageUrl] = React.useState<string | null>(null);
   const [showCurrentStage, setShowCurrentStage] = React.useState(false);
 
   React.useEffect(() => {
@@ -49,25 +48,6 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
     const timer = window.setTimeout(() => setShowCurrentStage(true), 120);
     return () => window.clearTimeout(timer);
   }, [data.studentId]);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    if (!student || data.avatarStageEnd <= data.avatarStageStart) {
-      setPreviousStageUrl(null);
-      return () => {
-        cancelled = true;
-      };
-    }
-    (async () => {
-      const url = await getAvatarStageUrl(state, student, data.avatarStageStart);
-      if (!cancelled) {
-        setPreviousStageUrl(url);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [student, state, data.avatarStageStart, data.avatarStageEnd]);
 
   if (!student) {
     return (
@@ -168,22 +148,6 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
         }}
       >
         <div style={{ position: 'relative', justifySelf: 'center' }}>
-          {evolved && (
-            <div
-              aria-hidden
-              style={{
-                position: 'absolute',
-                top: -24,
-                left: -24,
-                right: -24,
-                bottom: -24,
-                borderRadius: AVATAR_SIZE,
-                background:
-                  'radial-gradient(circle at center, rgba(253,224,71,0.4), rgba(253,224,71,0) 70%)',
-                filter: 'blur(12px)',
-              }}
-            />
-          )}
           <div
             style={{
               position: 'relative',
@@ -191,35 +155,29 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
               height: AVATAR_SIZE,
             }}
           >
-            {previousStageUrl && (
-              <img
-                src={previousStageUrl}
-                alt="Vorheriger Avatar"
+            {evolved ? (
+              <EvolutionSequence
+                student={student}
+                fromStage={data.avatarStageStart}
+                toStage={data.avatarStageEnd}
+                size={AVATAR_SIZE}
+                totalMs={2200}
+              />
+            ) : (
+              <div
                 style={{
                   position: 'absolute',
                   inset: 0,
-                  width: '100%',
-                  height: '100%',
-                  objectFit: 'cover',
-                  borderRadius: AVATAR_SIZE / 2,
-                  opacity: showCurrentStage ? 0 : 1,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  opacity: showCurrentStage ? 1 : 0,
                   transition: 'opacity 0.6s ease',
                 }}
-              />
+              >
+                <AvatarView student={student} size={AVATAR_SIZE} rounded="xl" />
+              </div>
             )}
-            <div
-              style={{
-                position: 'absolute',
-                inset: 0,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                opacity: showCurrentStage ? 1 : 0,
-                transition: 'opacity 0.6s ease',
-              }}
-            >
-              <AvatarView student={student} size={AVATAR_SIZE} rounded="xl" />
-            </div>
           </div>
         </div>
         <div style={{ display: 'grid', gap: 16 }}>


### PR DESCRIPTION
## Summary
- add an EvolutionSequence component that preloads old/new avatar stages and runs the shake/flash/crossfade timeline
- render the evolution sequence in WeeklyShowSlide when a student's avatar stage increases, falling back to the standard AvatarView otherwise

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d01a00a93c832c8fc932c30a92627f