### PR TITLE
feat: add asset settings and effects utilities

### DIFF
--- a/classquest/src/__tests__/badges.autorules.test.ts
+++ b/classquest/src/__tests__/badges.autorules.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { selectStudentCategoryXp, shouldAutoAward } from '~/core/selectors/badges';
 import type { AppState, Student, BadgeDefinition } from '~/types/models';
+import { createDefaultAssetSettings } from '~/types/settings';
 
 type Mutable<T> = {
   -readonly [K in keyof T]: T[K];
@@ -90,6 +91,7 @@ const baseState: Mutable<AppState> = {
     classMilestoneStep: 1000,
     classStarIconKey: null,
     classStarsName: 'Stern',
+    assets: createDefaultAssetSettings(),
   },
   version: 1,
   classProgress: { totalXP: 0, stars: 0 },

--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -1,4 +1,5 @@
 import type { Settings } from '~/types/models';
+import { createDefaultAssetSettings } from '~/types/settings';
 export const DEFAULT_SETTINGS: Required<Settings> = {
   className: 'Meine Klasse',
   xpPerLevel: 100,
@@ -15,4 +16,5 @@ export const DEFAULT_SETTINGS: Required<Settings> = {
   classStarIconKey: null,
   classMilestoneStep: 1000,
   classStarsName: 'Stern',
+  assets: createDefaultAssetSettings(),
 };

--- a/classquest/src/core/show/avatarStageUrl.ts
+++ b/classquest/src/core/show/avatarStageUrl.ts
@@ -13,7 +13,7 @@ function sanitizeStageKeys(pack?: Student['avatarPack']): (string | null)[] {
 }
 
 export async function getAvatarStageUrl(
-  state: AppState,
+  _state: AppState,
   student: Student,
   stage: number,
 ): Promise<string | null> {

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_SETTINGS } from './config';
 import { processAward } from './gameLogic';
 import { levelFromXP } from './xp';
+import { sanitizeAssetSettings } from '~/types/settings';
 import type {
   AppState,
   ID,
@@ -68,14 +69,18 @@ export const createInitialState = (
   teams: [],
   quests: [],
   logs: [],
-  settings: {
-    ...DEFAULT_SETTINGS,
-    ...settings,
-    flags: {
-      ...(DEFAULT_SETTINGS.flags ?? {}),
-      ...((settings?.flags ?? {}) as Record<string, boolean>),
-    },
-  },
+  settings: (() => {
+    const { flags, assets, ...restSettings } = settings ?? {};
+    return {
+      ...DEFAULT_SETTINGS,
+      ...restSettings,
+      flags: {
+        ...(DEFAULT_SETTINGS.flags ?? {}),
+        ...((flags ?? {}) as Record<string, boolean>),
+      },
+      assets: sanitizeAssetSettings(assets ?? DEFAULT_SETTINGS.assets),
+    } satisfies Settings;
+  })(),
   version,
   classProgress: { totalXP: 0, stars: 0 },
   badgeDefs: [],

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,3 +1,7 @@
+import type { AssetSettings } from './settings';
+
+export type { AssetEvent, AssetRef, AssetSettings } from './settings';
+
 export type ID = string;
 
 export type BadgeRule =
@@ -83,6 +87,7 @@ export type Settings = {
   classStarIconKey?: string | null;
   classMilestoneStep?: number;
   classStarsName?: string;
+  assets: AssetSettings;
 };
 
 export type BadgeDefinition = {

--- a/classquest/src/types/settings.ts
+++ b/classquest/src/types/settings.ts
@@ -1,0 +1,184 @@
+export type AssetEvent =
+  | 'xp_awarded'
+  | 'badge_award'
+  | 'level_up'
+  | 'class_milestone'
+  | 'quest_completed'
+  | 'student_select'
+  | 'avatar_zoom'
+  | 'weekly_showcase_start'
+  | 'weekly_showcase_end'
+  | 'ui_click'
+  | 'ui_success'
+  | 'ui_error'
+  | 'undo'
+  | 'redo'
+  | 'import_success'
+  | 'export_success';
+
+export type AssetKind = 'audio' | 'lottie' | 'image';
+
+export interface AssetRef {
+  key: string;
+  type: AssetKind;
+  name: string;
+  createdAt: number;
+}
+
+export type AssetBindingMap = Partial<Record<AssetEvent, string>>;
+
+export interface AssetSettings {
+  library: Record<string, AssetRef>;
+  bindings: {
+    audio: AssetBindingMap;
+    lottie: AssetBindingMap;
+    image: AssetBindingMap;
+  };
+  audio: { masterVolume: number; enabled: boolean };
+  animations: { enabled: boolean; preferReducedMotion: boolean };
+}
+
+export const DEFAULT_ASSET_SETTINGS: Readonly<AssetSettings> = Object.freeze({
+  library: {},
+  bindings: {
+    audio: {},
+    lottie: {},
+    image: {},
+  },
+  audio: { masterVolume: 1, enabled: true },
+  animations: { enabled: true, preferReducedMotion: false },
+});
+
+export const createDefaultAssetSettings = (): AssetSettings => ({
+  library: {},
+  bindings: {
+    audio: {},
+    lottie: {},
+    image: {},
+  },
+  audio: { masterVolume: 1, enabled: true },
+  animations: { enabled: true, preferReducedMotion: false },
+});
+
+export const cloneAssetSettings = (settings: AssetSettings): AssetSettings => ({
+  library: Object.fromEntries(
+    Object.entries(settings.library ?? {}).map(([id, ref]) => [
+      id,
+      {
+        key: ref.key,
+        type: ref.type,
+        name: ref.name,
+        createdAt: ref.createdAt,
+      },
+    ]),
+  ),
+  bindings: {
+    audio: { ...(settings.bindings?.audio ?? {}) },
+    lottie: { ...(settings.bindings?.lottie ?? {}) },
+    image: { ...(settings.bindings?.image ?? {}) },
+  },
+  audio: {
+    masterVolume: settings.audio?.masterVolume ?? 1,
+    enabled: settings.audio?.enabled ?? true,
+  },
+  animations: {
+    enabled: settings.animations?.enabled ?? true,
+    preferReducedMotion: settings.animations?.preferReducedMotion ?? false,
+  },
+});
+
+const VALID_ASSET_KINDS: AssetKind[] = ['audio', 'lottie', 'image'];
+
+const asAssetKind = (value: unknown): AssetKind | null =>
+  typeof value === 'string' && (VALID_ASSET_KINDS as readonly string[]).includes(value)
+    ? (value as AssetKind)
+    : null;
+
+const asString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const asNumber = (value: unknown): number | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+};
+
+const clamp01 = (value: number | null | undefined, fallback: number): number => {
+  if (typeof value !== 'number' || Number.isNaN(value)) return fallback;
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(1, Math.max(0, value));
+};
+
+const sanitizeAssetRef = (value: unknown): AssetRef | null => {
+  if (typeof value !== 'object' || value === null) return null;
+  const record = value as Record<string, unknown>;
+  const key = asString(record.key);
+  const type = asAssetKind(record.type);
+  const name = asString(record.name) ?? 'Asset';
+  const createdAt = asNumber(record.createdAt) ?? Date.now();
+  if (!key || !type) return null;
+  return { key, type, name, createdAt } satisfies AssetRef;
+};
+
+const sanitizeAssetBindingMap = (value: unknown): AssetBindingMap => {
+  if (typeof value !== 'object' || value === null) return {};
+  const entries = Object.entries(value)
+    .map(([event, asset]) => {
+      if (typeof asset !== 'string') return null;
+      const trimmed = asset.trim();
+      if (!trimmed) return null;
+      return [event as AssetEvent, trimmed] as const;
+    })
+    .filter(Boolean) as [AssetEvent, string][];
+  return Object.fromEntries(entries);
+};
+
+export const sanitizeAssetSettings = (value: unknown): AssetSettings => {
+  const defaults = createDefaultAssetSettings();
+  if (typeof value !== 'object' || value === null) {
+    return defaults;
+  }
+  const record = value as Partial<AssetSettings> & Record<string, unknown>;
+  const libraryEntries = Object.entries((record.library ?? {}) as Record<string, unknown>).map(([id, candidate]) => {
+    const normalized = sanitizeAssetRef(candidate);
+    if (!normalized) return null;
+    return [id, normalized] as const;
+  });
+  const library = Object.fromEntries(libraryEntries.filter(Boolean) as [string, AssetRef][]);
+
+  const bindingsInput = (record.bindings ?? {}) as Partial<AssetSettings['bindings']>;
+  const bindings = {
+    audio: sanitizeAssetBindingMap(bindingsInput.audio),
+    lottie: sanitizeAssetBindingMap(bindingsInput.lottie),
+    image: sanitizeAssetBindingMap(bindingsInput.image),
+  } satisfies AssetSettings['bindings'];
+
+  const audioInput = (record.audio ?? {}) as Partial<AssetSettings['audio']>;
+  const audio = {
+    masterVolume: clamp01(asNumber(audioInput.masterVolume), defaults.audio.masterVolume),
+    enabled: typeof audioInput.enabled === 'boolean' ? audioInput.enabled : defaults.audio.enabled,
+  } satisfies AssetSettings['audio'];
+
+  const animationsInput = (record.animations ?? {}) as Partial<AssetSettings['animations']>;
+  const animations = {
+    enabled:
+      typeof animationsInput.enabled === 'boolean' ? animationsInput.enabled : defaults.animations.enabled,
+    preferReducedMotion:
+      typeof animationsInput.preferReducedMotion === 'boolean'
+        ? animationsInput.preferReducedMotion
+        : defaults.animations.preferReducedMotion,
+  } satisfies AssetSettings['animations'];
+
+  return {
+    library,
+    bindings,
+    audio,
+    animations,
+  } satisfies AssetSettings;
+};

--- a/classquest/src/utils/effects.ts
+++ b/classquest/src/utils/effects.ts
@@ -1,0 +1,378 @@
+import lottie, { type AnimationItem } from 'lottie-web';
+import { clearObjectURL, getObjectURL } from '~/services/blobStore';
+import type { Settings } from '~/types/models';
+import type { AssetEvent, AssetRef, AssetSettings } from '~/types/settings';
+import { cloneAssetSettings, createDefaultAssetSettings } from '~/types/settings';
+
+type LottieOptions = { mount?: HTMLElement; center?: boolean; durationMs?: number };
+
+const clampVolume = (value: number): number => {
+  if (!Number.isFinite(value)) return 1;
+  if (Number.isNaN(value)) return 1;
+  return Math.min(1, Math.max(0, value));
+};
+
+const resolveBlobKey = (recordId: string, ref: AssetRef | undefined): string | null => {
+  const keyCandidate = ref?.key ?? recordId;
+  if (typeof keyCandidate !== 'string') return null;
+  const trimmed = keyCandidate.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const collectBindingKeys = (bindings: Record<string, string | undefined>, assets: AssetSettings) => {
+  const keys = new Set<string>();
+  Object.values(bindings).forEach((value) => {
+    if (typeof value !== 'string') return;
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    const candidate = resolveBlobKey(trimmed, assets.library[trimmed]);
+    if (candidate) {
+      keys.add(candidate);
+    }
+  });
+  return keys;
+};
+
+const collectActiveBlobKeys = (assets: AssetSettings): Set<string> => {
+  const keys = new Set<string>();
+  Object.entries(assets.library).forEach(([recordId, ref]) => {
+    const blobKey = resolveBlobKey(recordId, ref);
+    if (blobKey) {
+      keys.add(blobKey);
+    }
+  });
+  const audioKeys = collectBindingKeys(assets.bindings.audio ?? {}, assets);
+  const lottieKeys = collectBindingKeys(assets.bindings.lottie ?? {}, assets);
+  const imageKeys = collectBindingKeys(assets.bindings.image ?? {}, assets);
+  audioKeys.forEach((key) => keys.add(key));
+  lottieKeys.forEach((key) => keys.add(key));
+  imageKeys.forEach((key) => keys.add(key));
+  return keys;
+};
+
+const DEFAULT_ASSETS = createDefaultAssetSettings();
+
+let currentAssets: AssetSettings = cloneAssetSettings(DEFAULT_ASSETS);
+let knownBlobKeys = collectActiveBlobKeys(currentAssets);
+let blobKeyToAsset = new Map<string, AssetRef>();
+
+const urlPromises = new Map<string, Promise<string | null>>();
+const resolvedUrls = new Map<string, string>();
+
+const updateAssetIndex = (assets: AssetSettings) => {
+  blobKeyToAsset = new Map();
+  Object.entries(assets.library).forEach(([recordId, ref]) => {
+    const blobKey = resolveBlobKey(recordId, ref);
+    if (blobKey) {
+      blobKeyToAsset.set(blobKey, ref);
+    }
+  });
+};
+
+updateAssetIndex(currentAssets);
+
+const purgeCachedAsset = (blobKey: string) => {
+  urlPromises.delete(blobKey);
+  const hasUrl = resolvedUrls.has(blobKey);
+  resolvedUrls.delete(blobKey);
+  try {
+    if (hasUrl) {
+      clearObjectURL(blobKey);
+    }
+  } catch (error) {
+    console.warn('Failed to revoke object URL', error);
+  }
+};
+
+const fetchAssetUrl = async (blobKey: string): Promise<string | null> => {
+  const cached = resolvedUrls.get(blobKey);
+  if (cached) return cached;
+  const existing = urlPromises.get(blobKey);
+  if (existing) {
+    return existing;
+  }
+  const promise = getObjectURL(blobKey)
+    .then((url) => {
+      if (!url) {
+        urlPromises.delete(blobKey);
+        resolvedUrls.delete(blobKey);
+        return null;
+      }
+      resolvedUrls.set(blobKey, url);
+      return url;
+    })
+    .catch((error) => {
+      console.warn('Failed to load asset', error);
+      urlPromises.delete(blobKey);
+      resolvedUrls.delete(blobKey);
+      return null;
+    });
+  urlPromises.set(blobKey, promise);
+  return promise;
+};
+
+const resolveBinding = (
+  kind: 'audio' | 'lottie' | 'image',
+  evt: AssetEvent,
+): { blobKey: string; ref: AssetRef | undefined } | null => {
+  const binding = currentAssets.bindings[kind]?.[evt];
+  if (!binding) return null;
+  const ref = currentAssets.library[binding];
+  if (ref && ref.type !== kind) {
+    return null;
+  }
+  const blobKey = resolveBlobKey(binding, ref);
+  if (!blobKey) return null;
+  return { blobKey, ref };
+};
+
+const getAudioConstructor = (): (typeof Audio) | null => {
+  if (typeof Audio === 'function') return Audio;
+  if (typeof window !== 'undefined') {
+    const candidate = (window as typeof window & { Audio?: typeof Audio }).Audio;
+    if (typeof candidate === 'function') return candidate;
+  }
+  return null;
+};
+
+const preloadAudio = async (url: string): Promise<void> => {
+  const AudioCtor = getAudioConstructor();
+  if (!AudioCtor) return;
+  await new Promise<void>((resolve) => {
+    try {
+      const audio = new AudioCtor();
+      audio.preload = 'auto';
+      const cleanup = () => {
+        audio.removeEventListener('canplaythrough', cleanup);
+        audio.removeEventListener('error', cleanup);
+        resolve();
+      };
+      audio.addEventListener('canplaythrough', cleanup, { once: true });
+      audio.addEventListener('error', cleanup, { once: true });
+      audio.src = url;
+      // calling load() ensures browsers fetch immediately
+      if (typeof audio.load === 'function') {
+        try {
+          audio.load();
+        } catch (error) {
+          resolve();
+        }
+      }
+    } catch (error) {
+      console.warn('Audio preload failed', error);
+      resolve();
+    }
+  });
+};
+
+const preloadImage = async (url: string): Promise<void> => {
+  if (typeof Image === 'undefined') return;
+  await new Promise<void>((resolve) => {
+    const img = new Image();
+    const finalize = () => {
+      img.onload = null;
+      img.onerror = null;
+      resolve();
+    };
+    img.onload = finalize;
+    img.onerror = finalize;
+    img.src = url;
+  });
+};
+
+const preloadLottie = async (url: string): Promise<void> => {
+  if (typeof fetch !== 'function') return;
+  try {
+    await fetch(url);
+  } catch (error) {
+    console.warn('Lottie preload failed', error);
+  }
+};
+
+const ensureOverlayRoot = (): HTMLDivElement | null => {
+  if (typeof document === 'undefined') return null;
+  const attribute = 'data-classquest-effects-root';
+  let node = document.body.querySelector<HTMLDivElement>(`[${attribute}]`);
+  if (node && node.parentElement === document.body) {
+    return node;
+  }
+  node = document.createElement('div');
+  node.setAttribute(attribute, '');
+  Object.assign(node.style, {
+    position: 'fixed',
+    inset: '0',
+    pointerEvents: 'none',
+    zIndex: '2147483647',
+    overflow: 'visible',
+  });
+  document.body.appendChild(node);
+  return node;
+};
+
+const createLottieContainer = (mount: HTMLElement, centered: boolean | undefined): HTMLElement => {
+  const container = document.createElement('div');
+  container.setAttribute('data-classquest-effect-instance', '');
+  container.style.pointerEvents = 'none';
+
+  if (mount.hasAttribute('data-classquest-effects-root')) {
+    container.style.position = 'absolute';
+    container.style.inset = '0';
+    if (centered !== false) {
+      container.style.display = 'flex';
+      container.style.alignItems = 'center';
+      container.style.justifyContent = 'center';
+    }
+  } else if (centered) {
+    container.style.display = 'flex';
+    container.style.alignItems = 'center';
+    container.style.justifyContent = 'center';
+    container.style.width = '100%';
+    container.style.height = '100%';
+  }
+
+  mount.appendChild(container);
+  return container;
+};
+
+const startLottieAnimation = (container: HTMLElement, url: string, durationOverride?: number): void => {
+  let animation: AnimationItem | null = null;
+  let fallbackTimer: number | undefined;
+  let disposed = false;
+
+  const cleanup = () => {
+    if (disposed) return;
+    disposed = true;
+    if (fallbackTimer) {
+      window.clearTimeout(fallbackTimer);
+      fallbackTimer = undefined;
+    }
+    try {
+      animation?.removeEventListener?.('complete', cleanup);
+      animation?.removeEventListener?.('destroy', cleanup);
+    } catch (error) {
+      console.warn('Failed to detach lottie listeners', error);
+    }
+    try {
+      animation?.destroy?.();
+    } catch (error) {
+      console.warn('Failed to destroy lottie animation', error);
+    }
+    container.remove();
+  };
+
+  const scheduleFallback = (duration: number) => {
+    if (fallbackTimer) {
+      window.clearTimeout(fallbackTimer);
+    }
+    fallbackTimer = window.setTimeout(cleanup, duration);
+  };
+
+  try {
+    animation = lottie.loadAnimation({
+      container,
+      renderer: 'svg',
+      loop: false,
+      autoplay: true,
+      path: url,
+      rendererSettings: {
+        preserveAspectRatio: 'xMidYMid meet',
+      },
+    });
+    animation.addEventListener('complete', cleanup);
+    animation.addEventListener('destroy', cleanup);
+    if (durationOverride != null) {
+      scheduleFallback(Math.max(0, durationOverride));
+    } else {
+      animation.addEventListener('data_ready', () => {
+        try {
+          const total = animation?.getDuration(true) ?? 0;
+          const fallback = total > 0 ? total * 1000 + 250 : 1800;
+          scheduleFallback(fallback);
+        } catch (error) {
+          console.warn('Failed to determine lottie duration', error);
+          scheduleFallback(2000);
+        }
+      });
+      scheduleFallback(2500);
+    }
+  } catch (error) {
+    console.warn('Failed to load lottie animation', error);
+    cleanup();
+  }
+};
+
+export const setEffectsSettings = (settings: Settings | null | undefined): void => {
+  const assets = settings?.assets ? cloneAssetSettings(settings.assets) : cloneAssetSettings(DEFAULT_ASSETS);
+  const activeKeys = collectActiveBlobKeys(assets);
+  knownBlobKeys.forEach((key) => {
+    if (!activeKeys.has(key)) {
+      purgeCachedAsset(key);
+    }
+  });
+  knownBlobKeys = activeKeys;
+  currentAssets = assets;
+  updateAssetIndex(assets);
+};
+
+export function playEventAudio(evt: AssetEvent): void {
+  if (typeof window === 'undefined') return;
+  if (!currentAssets.audio.enabled) return;
+  const binding = resolveBinding('audio', evt);
+  if (!binding) return;
+  const volume = clampVolume(currentAssets.audio.masterVolume ?? 1);
+  if (volume <= 0) return;
+  void fetchAssetUrl(binding.blobKey).then((url) => {
+    if (!url) return;
+    const AudioCtor = getAudioConstructor();
+    if (!AudioCtor) return;
+    try {
+      const audio = new AudioCtor(url);
+      audio.volume = volume;
+      void audio.play().catch((error: unknown) => {
+        console.warn('Failed to play audio asset', error);
+      });
+    } catch (error) {
+      console.warn('Unable to instantiate audio', error);
+    }
+  });
+}
+
+export function triggerEventLottie(evt: AssetEvent, opts?: LottieOptions): void {
+  if (typeof window === 'undefined') return;
+  const animations = currentAssets.animations;
+  if (!animations.enabled || animations.preferReducedMotion) {
+    return;
+  }
+  const binding = resolveBinding('lottie', evt);
+  if (!binding) return;
+  void fetchAssetUrl(binding.blobKey).then((url) => {
+    if (!url) return;
+    const mount = opts?.mount ?? ensureOverlayRoot();
+    if (!mount) return;
+    const container = createLottieContainer(mount, opts?.center);
+    startLottieAnimation(container, url, opts?.durationMs);
+  });
+}
+
+export async function preloadAssets(): Promise<void> {
+  const keys = Array.from(collectActiveBlobKeys(currentAssets));
+  if (!keys.length) return;
+  await Promise.all(
+    keys.map(async (blobKey) => {
+      const url = await fetchAssetUrl(blobKey);
+      if (!url) return;
+      const ref = blobKeyToAsset.get(blobKey);
+      try {
+        if (ref?.type === 'audio') {
+          await preloadAudio(url);
+        } else if (ref?.type === 'image') {
+          await preloadImage(url);
+        } else if (ref?.type === 'lottie') {
+          await preloadLottie(url);
+        }
+      } catch (error) {
+        console.warn('Failed to preload asset', error);
+      }
+    }),
+  );
+}

--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { processAward } from '~/core/gameLogic';
 import type { AppState, Quest, Student } from '~/types/models';
+import { createDefaultAssetSettings } from '~/types/settings';
 
 const createStudent = (overrides: Partial<Student> = {}): Student => ({
   id: 'student-1',
@@ -27,6 +28,7 @@ const createState = (studentOverrides: Partial<Student> = {}): AppState => {
       xpPerLevel: 100,
       streakThresholdForBadge: 2,
       allowNegativeXP: false,
+      assets: createDefaultAssetSettings(),
     },
     version: 1,
     classProgress: { totalXP, stars: Math.floor(totalXP / 1000) },
@@ -97,6 +99,7 @@ describe('processAward', () => {
         xpPerLevel: 100,
         streakThresholdForBadge: 2,
         allowNegativeXP: true,
+        assets: createDefaultAssetSettings(),
       },
     } satisfies AppState;
 

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalStorageAdapter, STORAGE_KEY } from '~/services/storage/localStorage';
 import type { AppState } from '~/types/models';
 import { sanitizeState } from '~/core/schema/appState';
+import { createDefaultAssetSettings } from '~/types/settings';
 
 type GlobalWithStorage = typeof globalThis & { localStorage?: Storage };
 
@@ -38,7 +39,13 @@ const sampleState = (): AppState => ({
   quests: [{ id: 'q1', name: 'Hausaufgaben', xp: 10, type: 'daily', target: 'individual', active: true }],
   categories: [],
   logs: [],
-  settings: { className: '4a', xpPerLevel: 100, streakThresholdForBadge: 5, allowNegativeXP: false },
+  settings: {
+    className: '4a',
+    xpPerLevel: 100,
+    streakThresholdForBadge: 5,
+    allowNegativeXP: false,
+    assets: createDefaultAssetSettings(),
+  },
   version: 1,
   classProgress: { totalXP: 10, stars: 0 },
   badgeDefs: [],


### PR DESCRIPTION
## Summary
- add typed asset settings with defaults and sanitization helpers
- extend settings normalization and schema to store asset bindings
- implement effects utility for audio and lottie playback and preload support
- update existing tests to include default asset settings

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0421629d4832c9e5a8565ef2d6ad2