### PR TITLE
Fix zod namespace import for app state schema

### DIFF
--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 import { DEFAULT_SETTINGS } from '../config';
 import { sanitizeAssetSettings } from '~/types/settings';
 


### PR DESCRIPTION
## Summary
- update the app state schema to import the zod API using a namespace import so the `z` symbol is always defined

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d13ef8db78832cb1dbabbcd911e3cb