### PR TITLE
Add assets settings tab with upload and event bindings

### DIFF
--- a/classquest/src/components/manage/AssetBindingRow.tsx
+++ b/classquest/src/components/manage/AssetBindingRow.tsx
@@ -1,0 +1,91 @@
+import type { AssetEvent } from '~/types/settings';
+
+type AssetOption = {
+  id: string;
+  name: string;
+};
+
+type AssetBindingRowProps = {
+  event: AssetEvent;
+  label: string;
+  description: string;
+  audioOptions: AssetOption[];
+  lottieOptions: AssetOption[];
+  audioValue?: string | null;
+  lottieValue?: string | null;
+  onChange: (kind: 'audio' | 'lottie', event: AssetEvent, key: string | null) => void;
+  onTest: (event: AssetEvent) => void;
+};
+
+export default function AssetBindingRow({
+  event: assetEvent,
+  label,
+  description,
+  audioOptions,
+  lottieOptions,
+  audioValue,
+  lottieValue,
+  onChange,
+  onTest,
+}: AssetBindingRowProps) {
+  const canTest = Boolean(audioValue) || Boolean(lottieValue);
+
+  return (
+    <tr>
+      <th scope="row" style={{ textAlign: 'left', padding: '10px 8px' }}>
+        <div style={{ display: 'grid', gap: 2 }}>
+          <span style={{ fontWeight: 600 }}>{label}</span>
+          <span style={{ fontSize: 12, color: '#64748b' }}>{description}</span>
+        </div>
+      </th>
+      <td style={{ padding: '10px 8px' }}>
+        <select
+          value={audioValue ?? ''}
+          onChange={(changeEvent) => onChange('audio', assetEvent, changeEvent.target.value || null)}
+          aria-label={`Audio-Binding für ${label}`}
+          style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5f5', minWidth: 160 }}
+        >
+          <option value="">– Kein Audio –</option>
+          {audioOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td style={{ padding: '10px 8px' }}>
+        <select
+          value={lottieValue ?? ''}
+          onChange={(changeEvent) => onChange('lottie', assetEvent, changeEvent.target.value || null)}
+          aria-label={`Animations-Binding für ${label}`}
+          style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5f5', minWidth: 160 }}
+        >
+          <option value="">– Keine Animation –</option>
+          {lottieOptions.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.name}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td style={{ padding: '10px 8px' }}>
+        <button
+          type="button"
+          onClick={() => onTest(assetEvent)}
+          disabled={!canTest}
+          style={{
+            padding: '6px 12px',
+            borderRadius: 8,
+            border: '1px solid #4ade80',
+            backgroundColor: canTest ? '#bbf7d0' : '#e2e8f0',
+            color: '#166534',
+            fontWeight: 600,
+            cursor: canTest ? 'pointer' : 'not-allowed',
+          }}
+        >
+          Testen
+        </button>
+      </td>
+    </tr>
+  );
+}

--- a/classquest/src/components/manage/AssetPreviewList.tsx
+++ b/classquest/src/components/manage/AssetPreviewList.tsx
@@ -1,0 +1,313 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import lottie, { type AnimationItem } from 'lottie-web';
+import { blobStore } from '~/utils/blobStore';
+import type { AssetRef } from '~/types/settings';
+
+type AssetListEntry = {
+  id: string;
+  ref: AssetRef;
+};
+
+type AssetPreviewListProps = {
+  assets: AssetListEntry[];
+  onRename: (id: string, name: string) => Promise<void> | void;
+  onDelete: (id: string) => Promise<void> | void;
+};
+
+type AssetPreviewItemProps = {
+  entry: AssetListEntry;
+  onRename: (id: string, name: string) => Promise<void> | void;
+  onDelete: (id: string) => Promise<void> | void;
+};
+
+function useObjectUrl(key: string | null | undefined) {
+  const [url, setUrl] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (!key) {
+      setUrl(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+    (async () => {
+      try {
+        const objectUrl = await blobStore.getObjectUrl(key);
+        if (!cancelled) {
+          setUrl(objectUrl);
+        }
+      } catch (error) {
+        console.warn('Konnte Asset-URL nicht laden', error);
+        if (!cancelled) {
+          setUrl(null);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+  return url;
+}
+
+function LottiePreview({ url, loop }: { url: string | null; loop: boolean }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!url || !container) {
+      if (container) {
+        container.innerHTML = '';
+      }
+      return;
+    }
+
+    let animation: AnimationItem | null = null;
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const response = await fetch(url);
+        if (!response.ok) {
+          return;
+        }
+        const data = await response.json();
+        if (cancelled) {
+          return;
+        }
+        animation = lottie.loadAnimation({
+          container,
+          renderer: 'svg',
+          loop,
+          autoplay: true,
+          animationData: data,
+        });
+      } catch (error) {
+        console.warn('Lottie-Vorschau fehlgeschlagen', error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (animation) {
+        animation.destroy();
+      }
+      if (container) {
+        container.innerHTML = '';
+      }
+    };
+  }, [loop, url]);
+
+  return (
+    <div
+      ref={containerRef}
+      aria-label="Lottie-Vorschau"
+      style={{ width: 120, height: 120, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+    />
+  );
+}
+
+function AssetPreviewItem({ entry, onRename, onDelete }: AssetPreviewItemProps) {
+  const [name, setName] = useState(entry.ref.name);
+  const [deleting, setDeleting] = useState(false);
+  const [loop, setLoop] = useState(true);
+  const url = useObjectUrl(entry.ref.key ?? entry.id);
+
+  useEffect(() => {
+    setName(entry.ref.name);
+  }, [entry.ref.name]);
+
+  const createdAt = useMemo(() => new Date(entry.ref.createdAt), [entry.ref.createdAt]);
+
+  const commitRename = async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setName(entry.ref.name);
+      return;
+    }
+    if (trimmed === entry.ref.name) {
+      return;
+    }
+    setName(trimmed);
+    try {
+      await onRename(entry.id, trimmed);
+    } catch (error) {
+      console.warn('Asset-Umbenennung fehlgeschlagen', error);
+      setName(entry.ref.name);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (deleting) return;
+    const confirmed = window.confirm(`Asset „${entry.ref.name}“ wirklich löschen?`);
+    if (!confirmed) return;
+    setDeleting(true);
+    try {
+      await onDelete(entry.id);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <li
+      style={{
+        border: '1px solid #e2e8f0',
+        borderRadius: 12,
+        padding: 12,
+        display: 'grid',
+        gap: 12,
+        backgroundColor: '#f8fafc',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center', flexWrap: 'wrap' }}>
+        <div
+          style={{
+            width: 120,
+            height: 120,
+            borderRadius: 12,
+            backgroundColor: '#fff',
+            border: '1px solid #cbd5f5',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            overflow: 'hidden',
+          }}
+        >
+          {entry.ref.type === 'audio' && url ? (
+            <audio controls preload="metadata" src={url} style={{ width: '100%' }} aria-label="Audio-Vorschau" />
+          ) : entry.ref.type === 'image' && url ? (
+            <img
+              src={url}
+              alt={`Vorschau von ${entry.ref.name}`}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          ) : entry.ref.type === 'lottie' ? (
+            <LottiePreview url={url} loop={loop} />
+          ) : (
+            <span style={{ fontSize: 32 }}>📁</span>
+          )}
+        </div>
+        <div style={{ flex: 1, minWidth: 200, display: 'grid', gap: 8 }}>
+          <label style={{ display: 'grid', gap: 4 }}>
+            <span style={{ fontWeight: 600 }}>Name</span>
+            <input
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              onBlur={() => {
+                void commitRename();
+              }}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  void commitRename();
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault();
+                  setName(entry.ref.name);
+                }
+              }}
+              aria-label={`Asset ${entry.ref.name} umbenennen`}
+              style={{
+                padding: '8px 10px',
+                borderRadius: 8,
+                border: '1px solid #cbd5f5',
+                fontSize: 14,
+              }}
+            />
+          </label>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+            <span
+              style={{
+                padding: '4px 8px',
+                borderRadius: 6,
+                fontSize: 12,
+                backgroundColor: '#e0e7ff',
+                color: '#3730a3',
+                fontWeight: 600,
+              }}
+            >
+              {entry.ref.type.toUpperCase()}
+            </span>
+            <span style={{ fontSize: 12, color: '#64748b' }}>
+              Hinzugefügt am {createdAt.toLocaleDateString()} {createdAt.toLocaleTimeString()}
+            </span>
+            {entry.ref.type === 'lottie' && (
+              <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 12 }}>
+                <input
+                  type="checkbox"
+                  checked={loop}
+                  onChange={(event) => setLoop(event.target.checked)}
+                />
+                Loop
+              </label>
+            )}
+          </div>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={deleting}
+            style={{
+              padding: '8px 12px',
+              borderRadius: 8,
+              border: '1px solid #ef4444',
+              backgroundColor: deleting ? '#fee2e2' : '#fecaca',
+              color: '#7f1d1d',
+              fontWeight: 600,
+              cursor: deleting ? 'progress' : 'pointer',
+            }}
+          >
+            {deleting ? 'Löscht…' : 'Löschen'}
+          </button>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default function AssetPreviewList({ assets, onRename, onDelete }: AssetPreviewListProps) {
+  const [query, setQuery] = useState('');
+
+  const filteredAssets = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    if (!term) {
+      return assets;
+    }
+    return assets.filter(({ ref }) => ref.name.toLowerCase().includes(term));
+  }, [assets, query]);
+
+  return (
+    <section style={{ display: 'grid', gap: 12 }} aria-label="Asset-Bibliothek">
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 12 }}>
+        <h3 style={{ margin: 0, fontSize: 18 }}>Bibliothek</h3>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ fontSize: 14 }}>Suche</span>
+          <input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Nach Namen filtern…"
+            style={{
+              padding: '6px 10px',
+              borderRadius: 8,
+              border: '1px solid #cbd5f5',
+              minWidth: 200,
+            }}
+          />
+        </label>
+      </header>
+      {filteredAssets.length === 0 ? (
+        <p style={{ margin: 0, color: '#64748b' }}>Keine Assets gefunden.</p>
+      ) : (
+        <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'grid', gap: 12 }}>
+          {filteredAssets.map((entry) => (
+            <AssetPreviewItem key={entry.id} entry={entry} onRename={onRename} onDelete={onDelete} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/classquest/src/components/manage/AssetUploadCard.tsx
+++ b/classquest/src/components/manage/AssetUploadCard.tsx
@@ -1,0 +1,117 @@
+import { type ChangeEvent, useId, useRef, useState } from 'react';
+
+export type AssetUploadCardProps = {
+  title: string;
+  description: string;
+  accept: string;
+  hint: string;
+  onUpload: (file: File) => Promise<void>;
+  validate?: (file: File) => string | null;
+};
+
+export default function AssetUploadCard({
+  title,
+  description,
+  accept,
+  hint,
+  onUpload,
+  validate,
+}: AssetUploadCardProps) {
+  const inputId = useId();
+  const hintId = useId();
+  const errorId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const openFilePicker = () => {
+    inputRef.current?.click();
+  };
+
+  const handleChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+    const validationError = validate?.(file) ?? null;
+    if (validationError) {
+      setError(validationError);
+      event.target.value = '';
+      return;
+    }
+    setError(null);
+    setUploading(true);
+    try {
+      await onUpload(file);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Upload fehlgeschlagen';
+      setError(message);
+    } finally {
+      setUploading(false);
+      if (inputRef.current) {
+        inputRef.current.value = '';
+      }
+    }
+  };
+
+  return (
+    <section
+      aria-labelledby={inputId}
+      style={{
+        border: '1px solid #d0d7e6',
+        borderRadius: 12,
+        padding: 16,
+        display: 'grid',
+        gap: 12,
+        backgroundColor: '#fff',
+      }}
+    >
+      <header style={{ display: 'grid', gap: 4 }}>
+        <h3 id={inputId} style={{ margin: 0, fontSize: 18 }}>
+          {title}
+        </h3>
+        <p style={{ margin: 0, color: '#475569', fontSize: 14 }}>{description}</p>
+      </header>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+        <button
+          type="button"
+          onClick={openFilePicker}
+          disabled={uploading}
+          style={{
+            padding: '8px 14px',
+            borderRadius: 10,
+            border: '1px solid #7c3aed',
+            backgroundColor: uploading ? '#ede9fe' : '#c4b5fd',
+            color: '#1f2937',
+            fontWeight: 600,
+            cursor: uploading ? 'progress' : 'pointer',
+          }}
+        >
+          {uploading ? 'Lädt…' : 'Datei auswählen'}
+        </button>
+        <span style={{ fontSize: 12, color: '#64748b' }}>Erlaubt: {accept}</span>
+        <input
+          ref={inputRef}
+          id={`${inputId}-input`}
+          type="file"
+          accept={accept}
+          onChange={handleChange}
+          aria-describedby={`${hintId}${error ? ` ${errorId}` : ''}`}
+          style={{ display: 'none' }}
+        />
+      </div>
+      <p id={hintId} style={{ margin: 0, fontSize: 12, color: '#64748b' }}>
+        {hint}
+      </p>
+      {error && (
+        <p
+          id={errorId}
+          role="alert"
+          style={{ margin: 0, fontSize: 13, color: '#b91c1c', fontWeight: 600 }}
+        >
+          {error}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/classquest/src/screens/manage/AssetsTab.tsx
+++ b/classquest/src/screens/manage/AssetsTab.tsx
@@ -1,0 +1,366 @@
+import { useMemo, useState } from 'react';
+import { useApp } from '~/app/AppContext';
+import { useFeedback } from '~/ui/feedback/FeedbackProvider';
+import AssetUploadCard from '~/components/manage/AssetUploadCard';
+import AssetPreviewList from '~/components/manage/AssetPreviewList';
+import AssetBindingRow from '~/components/manage/AssetBindingRow';
+import { blobStore } from '~/utils/blobStore';
+import { playEventAudio, triggerEventLottie, preloadAssets } from '~/utils/effects';
+import {
+  type AssetEvent,
+  type AssetKind,
+  type AssetSettings,
+  cloneAssetSettings,
+  createDefaultAssetSettings,
+} from '~/types/settings';
+
+const AUDIO_TYPES = new Set([
+  'audio/mpeg',
+  'audio/mp3',
+  'audio/ogg',
+  'audio/wav',
+  'audio/x-wav',
+  'audio/x-pn-wav',
+]);
+
+const IMAGE_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/svg+xml',
+]);
+
+const LOTTIE_TYPES = new Set(['application/json']);
+
+const MAX_FILE_BYTES = 2 * 1024 * 1024;
+const MAX_LOTTIE_BYTES = 200 * 1024;
+
+const EVENT_DETAILS: Record<AssetEvent, { label: string; description: string }> = {
+  xp_awarded: { label: 'XP vergeben', description: 'Effekt bei XP-Vergabe.' },
+  badge_award: { label: 'Badge vergeben', description: 'Effekt bei Badge-Vergabe.' },
+  level_up: { label: 'Level-Up', description: 'Sound beim Level-Aufstieg.' },
+  class_milestone: { label: 'Klassen-Meilenstein', description: 'Effekt beim Klassen-Stern.' },
+  quest_completed: { label: 'Quest abgeschlossen', description: 'Effekt bei Quest-Abschluss.' },
+  student_select: { label: 'Schüler wechseln', description: 'Kurzer Tick beim Profilwechsel.' },
+  avatar_zoom: { label: 'Avatar-Zoom', description: 'Whoosh beim Avatar-Zoom.' },
+  weekly_showcase_start: { label: 'Showcase Start', description: 'Intro im Showcase.' },
+  weekly_showcase_end: { label: 'Showcase Ende', description: 'Outro im Showcase.' },
+  ui_click: { label: 'UI Klick', description: 'UI-Feedback beim Klicken.' },
+  ui_success: { label: 'UI Erfolg', description: 'Positive Rückmeldung.' },
+  ui_error: { label: 'UI Fehler', description: 'Hinweis bei Fehlern.' },
+  undo: { label: 'Aktion rückgängig', description: 'Sound beim Rückgängig machen.' },
+  redo: { label: 'Aktion wiederholen', description: 'Sound beim Wiederholen.' },
+  import_success: { label: 'Import erfolgreich', description: 'Signal nach erfolgreichem Import.' },
+  export_success: { label: 'Export erfolgreich', description: 'Signal nach erfolgreichem Export.' },
+};
+
+const ALL_EVENTS: AssetEvent[] = Object.keys(EVENT_DETAILS) as AssetEvent[];
+
+const fileMatches = (file: File, types: Set<string>, extensions: string[]): boolean => {
+  if (file.type && types.has(file.type.toLowerCase())) {
+    return true;
+  }
+  const lower = file.name.toLowerCase();
+  return extensions.some((ext) => lower.endsWith(ext));
+};
+
+const createAssetKey = () => `asset:${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+
+const toPercent = (value: number | undefined) => Math.round((Math.max(0, Math.min(1, value ?? 1))) * 100);
+
+const fromPercent = (value: number) => Math.max(0, Math.min(1, value / 100));
+
+export default function AssetsTab() {
+  const { state, dispatch } = useApp();
+  const feedback = useFeedback();
+  const assets = state.settings.assets ?? createDefaultAssetSettings();
+  const [preloading, setPreloading] = useState(false);
+
+  const updateAssets = (updater: (draft: AssetSettings) => void, message?: string) => {
+    const draft = cloneAssetSettings(state.settings.assets ?? createDefaultAssetSettings());
+    updater(draft);
+    dispatch({ type: 'UPDATE_SETTINGS', updates: { assets: draft } });
+    if (message) {
+      feedback.success(message);
+    }
+  };
+
+  const libraryEntries = useMemo(
+    () =>
+      Object.entries(assets.library ?? {})
+        .map(([id, ref]) => ({ id, ref }))
+        .sort((a, b) => b.ref.createdAt - a.ref.createdAt),
+    [assets.library],
+  );
+
+  const audioOptions = useMemo(
+    () => libraryEntries.filter(({ ref }) => ref.type === 'audio').map(({ id, ref }) => ({ id, name: ref.name })),
+    [libraryEntries],
+  );
+
+  const lottieOptions = useMemo(
+    () => libraryEntries.filter(({ ref }) => ref.type === 'lottie').map(({ id, ref }) => ({ id, name: ref.name })),
+    [libraryEntries],
+  );
+
+  const validateAudio = (file: File) => {
+    if (!fileMatches(file, AUDIO_TYPES, ['.mp3', '.ogg', '.wav'])) {
+      return 'Ungültiger Dateityp. Bitte MP3, OGG oder WAV verwenden.';
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      return 'Datei ist zu groß (max. 2 MB).';
+    }
+    return null;
+  };
+
+  const validateImage = (file: File) => {
+    if (!fileMatches(file, IMAGE_TYPES, ['.png', '.jpg', '.jpeg', '.webp', '.svg'])) {
+      return 'Ungültiger Dateityp. Bitte PNG, JPG, WEBP oder SVG verwenden.';
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      return 'Datei ist zu groß (max. 2 MB).';
+    }
+    return null;
+  };
+
+  const validateLottie = (file: File) => {
+    if (!fileMatches(file, LOTTIE_TYPES, ['.json'])) {
+      return 'Ungültiger Dateityp. Bitte Lottie-JSON verwenden.';
+    }
+    if (file.size > MAX_LOTTIE_BYTES) {
+      return 'Animation ist sehr groß (empfohlen < 500 KB).';
+    }
+    return null;
+  };
+
+  const handleUpload = async (file: File, type: AssetKind) => {
+    const key = createAssetKey();
+    try {
+      const storedKey = await blobStore.put(key, file);
+      const name = file.name?.trim() || `${type} Asset`;
+      updateAssets((draft) => {
+        draft.library[storedKey] = {
+          key: storedKey,
+          type,
+          name,
+          createdAt: Date.now(),
+        };
+      });
+      feedback.success('Asset gespeichert');
+    } catch (error) {
+      console.error('Upload fehlgeschlagen', error);
+      throw error instanceof Error ? error : new Error('Asset konnte nicht gespeichert werden.');
+    }
+  };
+
+  const handleRename = async (id: string, name: string) => {
+    updateAssets((draft) => {
+      const target = draft.library[id];
+      if (!target) return;
+      target.name = name.trim() || target.name;
+    }, 'Name aktualisiert');
+  };
+
+  const handleDelete = async (id: string) => {
+    const entry = assets.library[id];
+    updateAssets((draft) => {
+      delete draft.library[id];
+      (['audio', 'lottie', 'image'] as const).forEach((kind) => {
+        const bindingMap = draft.bindings[kind];
+        Object.entries(bindingMap).forEach(([evt, value]) => {
+          if (value === id) {
+            delete bindingMap[evt as AssetEvent];
+          }
+        });
+      });
+    });
+    if (entry?.key) {
+      await blobStore.remove(entry.key);
+    }
+    feedback.success('Asset entfernt');
+  };
+
+  const handleBindingChange = (kind: 'audio' | 'lottie', event: AssetEvent, key: string | null) => {
+    updateAssets((draft) => {
+      if (key) {
+        draft.bindings[kind][event] = key;
+      } else {
+        delete draft.bindings[kind][event];
+      }
+    }, 'Verknüpfung gespeichert');
+  };
+
+  const handleTest = (event: AssetEvent) => {
+    playEventAudio(event);
+    triggerEventLottie(event, { center: true });
+  };
+
+  const handlePreload = async () => {
+    if (preloading) return;
+    setPreloading(true);
+    try {
+      await preloadAssets();
+      feedback.success('Assets vorgeladen');
+    } catch (error) {
+      console.error('Preload fehlgeschlagen', error);
+      feedback.error('Preload fehlgeschlagen');
+    } finally {
+      setPreloading(false);
+    }
+  };
+
+  const audioEnabled = assets.audio?.enabled ?? true;
+  const animationEnabled = assets.animations?.enabled ?? true;
+  const reducedMotion = assets.animations?.preferReducedMotion ?? false;
+  const volumePercent = toPercent(assets.audio?.masterVolume);
+
+  return (
+    <div style={{ display: 'grid', gap: 24 }}>
+      <section style={{ display: 'grid', gap: 16 }} aria-label="Assets hochladen">
+        <h2 style={{ margin: 0, fontSize: 20 }}>Upload</h2>
+        <div
+          style={{
+            display: 'grid',
+            gap: 16,
+            gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+          }}
+        >
+          <AssetUploadCard
+            title="Sound hochladen"
+            description="Kurze Soundeffekte für XP, UI und mehr."
+            accept=".mp3,.ogg,.wav"
+            hint="Bitte MP3, OGG oder WAV hochladen (kurze Sounds &lt; 1s empfohlen)."
+            validate={validateAudio}
+            onUpload={(file) => handleUpload(file, 'audio')}
+          />
+          <AssetUploadCard
+            title="Lottie-Animation hochladen"
+            description="Animationsdatei im JSON-Format."
+            accept=".json"
+            hint="Bitte Lottie-JSON hochladen (optimiert, &lt;500 KB empfohlen)."
+            validate={validateLottie}
+            onUpload={(file) => handleUpload(file, 'lottie')}
+          />
+          <AssetUploadCard
+            title="Grafik hochladen"
+            description="Bilder für Avatare, Badges oder Klassenstars."
+            accept=".png,.jpg,.jpeg,.webp,.svg"
+            hint="Bitte PNG, JPG, WEBP oder SVG hochladen (max. 2 MB)."
+            validate={validateImage}
+            onUpload={(file) => handleUpload(file, 'image')}
+          />
+        </div>
+      </section>
+
+      <AssetPreviewList assets={libraryEntries} onRename={handleRename} onDelete={handleDelete} />
+
+      <section style={{ display: 'grid', gap: 12 }} aria-label="Event-Zuordnungen">
+        <h2 style={{ margin: 0, fontSize: 20 }}>Event-Mapping</h2>
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', padding: '8px' }}>Event</th>
+                <th style={{ textAlign: 'left', padding: '8px' }}>Audio</th>
+                <th style={{ textAlign: 'left', padding: '8px' }}>Animation</th>
+                <th style={{ textAlign: 'left', padding: '8px' }}>Test</th>
+              </tr>
+            </thead>
+            <tbody>
+              {ALL_EVENTS.map((event) => (
+                <AssetBindingRow
+                  key={event}
+                  event={event}
+                  label={EVENT_DETAILS[event].label}
+                  description={EVENT_DETAILS[event].description}
+                  audioOptions={audioOptions}
+                  lottieOptions={lottieOptions}
+                  audioValue={assets.bindings?.audio?.[event] ?? null}
+                  lottieValue={assets.bindings?.lottie?.[event] ?? null}
+                  onChange={handleBindingChange}
+                  onTest={handleTest}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section style={{ display: 'grid', gap: 16 }} aria-label="Globale Einstellungen">
+        <h2 style={{ margin: 0, fontSize: 20 }}>Globale Einstellungen</h2>
+        <div style={{ display: 'grid', gap: 12 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={audioEnabled}
+              onChange={(event) =>
+                updateAssets((draft) => {
+                  draft.audio.enabled = event.target.checked;
+                }, event.target.checked ? 'Audio aktiviert' : 'Audio deaktiviert')
+              }
+            />
+            Audio aktiv
+          </label>
+          <label style={{ display: 'grid', gap: 6, maxWidth: 320 }}>
+            <span>Master-Volume: {volumePercent}%</span>
+            <input
+              type="range"
+              min={0}
+              max={100}
+              value={volumePercent}
+              onChange={(event) => {
+                const value = Number.parseInt(event.target.value, 10) || 0;
+                updateAssets((draft) => {
+                  draft.audio.masterVolume = fromPercent(value);
+                });
+              }}
+            />
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={animationEnabled}
+              onChange={(event) =>
+                updateAssets((draft) => {
+                  draft.animations.enabled = event.target.checked;
+                }, event.target.checked ? 'Animationen aktiviert' : 'Animationen deaktiviert')
+              }
+            />
+            Animationen aktiv
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <input
+              type="checkbox"
+              checked={reducedMotion}
+              onChange={(event) =>
+                updateAssets((draft) => {
+                  draft.animations.preferReducedMotion = event.target.checked;
+                }, event.target.checked ? 'Reduzierte Bewegung bevorzugt' : 'Volle Bewegung bevorzugt')
+              }
+            />
+            Reduzierte Bewegungen bevorzugen
+          </label>
+        </div>
+        <div>
+          <button
+            type="button"
+            onClick={handlePreload}
+            disabled={preloading}
+            style={{
+              padding: '8px 16px',
+              borderRadius: 10,
+              border: '1px solid #38bdf8',
+              backgroundColor: preloading ? '#bae6fd' : '#e0f2fe',
+              color: '#0f172a',
+              fontWeight: 600,
+              cursor: preloading ? 'progress' : 'pointer',
+            }}
+          >
+            {preloading ? 'Lädt…' : 'Alle Assets preladen'}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/classquest/src/services/blobStore/indexedDb.ts
+++ b/classquest/src/services/blobStore/indexedDb.ts
@@ -118,26 +118,27 @@ function revokeCachedUrl(id: string) {
   urlCache.delete(id);
 }
 
-export async function putBlob(file: Blob): Promise<string> {
-  const id = createId();
+export async function putBlob(file: Blob, id?: string): Promise<string> {
+  const trimmed = typeof id === 'string' ? id.trim() : '';
+  const recordId = trimmed.length > 0 ? trimmed : createId();
   const db = await getDatabase();
 
   if (db) {
     try {
       await runTransaction(db, 'readwrite', (store) => {
-        store.put(file, id);
+        store.put(file, recordId);
       });
     } catch (error) {
       console.warn('IndexedDB put failed, switching to memory store.', error);
       ensureMemoryStore();
-      memoryStore.set(id, file);
+      memoryStore.set(recordId, file);
     }
   } else {
-    memoryStore.set(id, file);
+    memoryStore.set(recordId, file);
   }
 
-  cacheUrl(id, file);
-  return id;
+  cacheUrl(recordId, file);
+  return recordId;
 }
 
 export async function getBlob(id: string): Promise<Blob | null> {

--- a/classquest/src/ui/screens/ManageScreen.tsx
+++ b/classquest/src/ui/screens/ManageScreen.tsx
@@ -10,6 +10,7 @@ import { DEFAULT_SETTINGS } from '~/core/config';
 import StudentDetailScreen from '~/ui/screens/StudentDetailScreen';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import { CollapsibleSection, useCollapsibleState } from '~/ui/components/CollapsibleSection';
+import AssetsTab from '~/screens/manage/AssetsTab';
 import ManageSnapshots from '~/ui/manage/ManageSnapshots';
 
 const questTypes: QuestType[] = ['daily', 'repeatable', 'oneoff'];
@@ -898,6 +899,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
   const badgesCollapse = useCollapsibleState('manage-badges', true);
   const questsCollapse = useCollapsibleState('manage-quests', true);
   const groupsCollapse = useCollapsibleState('manage-groups', true);
+  const assetsCollapse = useCollapsibleState('manage-assets', true);
   const settingsCollapse = useCollapsibleState('manage-settings', true);
   const resetCollapse = useCollapsibleState('manage-season-reset', true);
   const backupCollapse = useCollapsibleState('manage-backup', true);
@@ -912,6 +914,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
         badgesCollapse,
         questsCollapse,
         groupsCollapse,
+        assetsCollapse,
         settingsCollapse,
         resetCollapse,
         backupCollapse,
@@ -924,6 +927,7 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
       badgesCollapse,
       questsCollapse,
       groupsCollapse,
+      assetsCollapse,
       settingsCollapse,
       resetCollapse,
       backupCollapse,
@@ -2054,6 +2058,10 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
           ))}
           {sortedTeams.length === 0 && <em>Noch keine Gruppen angelegt.</em>}
         </ul>
+      </CollapsibleSection>
+
+      <CollapsibleSection id="manage-assets" title="Assets" state={assetsCollapse}>
+        <AssetsTab />
       </CollapsibleSection>
 
       <CollapsibleSection id="manage-settings" title="Einstellungen" state={settingsCollapse}>

--- a/classquest/src/utils/blobStore.ts
+++ b/classquest/src/utils/blobStore.ts
@@ -1,0 +1,27 @@
+import { deleteBlob, getObjectURL, putBlob } from '~/services/blobStore';
+
+const normalizeKey = (key?: string | null): string | undefined => {
+  if (typeof key !== 'string') {
+    return undefined;
+  }
+  const trimmed = key.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+async function put(key: string | null | undefined, file: Blob): Promise<string> {
+  const storedKey = await putBlob(file, normalizeKey(key));
+  return storedKey;
+}
+
+async function remove(key: string): Promise<void> {
+  if (!key) return;
+  await deleteBlob(key);
+}
+
+export const blobStore = {
+  put,
+  getObjectUrl: getObjectURL,
+  remove,
+};
+
+export type BlobStore = typeof blobStore;

--- a/classquest/src/utils/effects.ts
+++ b/classquest/src/utils/effects.ts
@@ -154,7 +154,7 @@ const preloadAudio = async (url: string): Promise<void> => {
       if (typeof audio.load === 'function') {
         try {
           audio.load();
-        } catch (error) {
+        } catch {
           resolve();
         }
       }


### PR DESCRIPTION
## Summary
- extend the blob store to support stable asset keys and expose a small helper
- add asset upload, preview, and event binding components plus a dedicated assets tab
- wire the new tab into the manage screen with global audio/animation controls and runtime sync

## Testing
- npm run lint
- npm run typecheck
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d14be43a50832c9938bdc9a0fc1f0e