### PR TITLE
Fix zod import to prevent "z" reference errors

### DIFF
--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import { z } from 'zod';
 import { DEFAULT_SETTINGS } from '../config';
 import { sanitizeAssetSettings } from '~/types/settings';
 


### PR DESCRIPTION
## Summary
- switch the schema module to use the named `z` export from `zod`

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1510f4738832cb2618df3fda1245b