### PR TITLE
Fix zod import style for app state schema

### DIFF
--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 import { DEFAULT_SETTINGS } from '../config';
 import { sanitizeAssetSettings } from '~/types/settings';
 


### PR DESCRIPTION
## Summary
- change the app state schema to use the zod namespace import so schema helpers are always available

## Testing
- npm run typecheck
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d15973851c832cbc6d390916b6d4b2