### PR TITLE
Add snapshot sound system for weekly show

### DIFF
--- a/classquest/src/__tests__/badges.autorules.test.ts
+++ b/classquest/src/__tests__/badges.autorules.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { selectStudentCategoryXp, shouldAutoAward } from '~/core/selectors/badges';
 import type { AppState, Student, BadgeDefinition } from '~/types/models';
-import { createDefaultAssetSettings } from '~/types/settings';
+import {
+  createDefaultAssetSettings,
+  createDefaultSnapshotSoundSettings,
+  createDefaultSoundSettings,
+} from '~/types/settings';
 
 type Mutable<T> = {
   -readonly [K in keyof T]: T[K];
@@ -92,6 +96,8 @@ const baseState: Mutable<AppState> = {
     classStarIconKey: null,
     classStarsName: 'Stern',
     assets: createDefaultAssetSettings(),
+    sounds: createDefaultSoundSettings(),
+    snapshotSounds: createDefaultSnapshotSoundSettings(),
   },
   version: 1,
   classProgress: { totalXP: 0, stars: 0 },

--- a/classquest/src/app/AppContext.tsx
+++ b/classquest/src/app/AppContext.tsx
@@ -17,8 +17,9 @@ import { levelFromXP } from '~/core/xp';
 import { addQuest, addStudent, awardQuest, createInitialState, setQuestActive } from '~/core/state';
 import { sanitizeState } from '~/core/schema/appState';
 import { migrateState } from '~/core/schema/migrate';
-import { sanitizeAssetSettings } from '~/types/settings';
+import { sanitizeAssetSettings, sanitizeSnapshotSoundSettings, sanitizeSoundSettings } from '~/types/settings';
 import { setEffectsSettings } from '~/utils/effects';
+import { setSoundSettings } from '~/utils/sounds';
 
 type AwardPayload = { questId: ID; studentId?: ID; teamId?: ID; note?: string };
 
@@ -89,7 +90,7 @@ const normalizeStudentAvatar = (student: Student): Student => {
 };
 
 function normalizeSettings(settings?: Partial<Settings>): Settings {
-  const { assets, flags, ...rest } = settings ?? {};
+  const { assets, flags, sounds, snapshotSounds, ...rest } = settings ?? {};
   const merged: Settings = {
     ...DEFAULT_SETTINGS,
     ...rest,
@@ -98,6 +99,11 @@ function normalizeSettings(settings?: Partial<Settings>): Settings {
       ...((flags ?? {}) as Record<string, boolean>),
     },
     assets: sanitizeAssetSettings(assets ?? DEFAULT_SETTINGS.assets),
+    sounds: sanitizeSoundSettings(sounds ?? DEFAULT_SETTINGS.sounds, DEFAULT_SETTINGS.sounds),
+    snapshotSounds: sanitizeSnapshotSoundSettings(
+      snapshotSounds ?? DEFAULT_SETTINGS.snapshotSounds,
+      DEFAULT_SETTINGS.snapshotSounds,
+    ),
   };
   merged.avatarStageThresholds = sanitizeAvatarStageThresholds(merged.avatarStageThresholds);
   const rawStarKey =
@@ -687,6 +693,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
 
   React.useEffect(() => {
     setEffectsSettings(state.settings);
+    setSoundSettings(state.settings);
   }, [state.settings]);
 
   return <Ctx.Provider value={{ state, dispatch }}>{children}</Ctx.Provider>;

--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -1,5 +1,5 @@
 import type { Settings } from '~/types/models';
-import { createDefaultAssetSettings } from '~/types/settings';
+import { createDefaultAssetSettings, createDefaultSnapshotSoundSettings, createDefaultSoundSettings } from '~/types/settings';
 export const DEFAULT_SETTINGS: Required<Settings> = {
   className: 'Meine Klasse',
   xpPerLevel: 100,
@@ -17,4 +17,6 @@ export const DEFAULT_SETTINGS: Required<Settings> = {
   classMilestoneStep: 1000,
   classStarsName: 'Stern',
   assets: createDefaultAssetSettings(),
+  sounds: createDefaultSoundSettings(),
+  snapshotSounds: createDefaultSnapshotSoundSettings(),
 };

--- a/classquest/src/core/show/snapshotEvents.ts
+++ b/classquest/src/core/show/snapshotEvents.ts
@@ -1,34 +1,36 @@
-import type { AssetEvent } from '~/types/settings';
-
-export type SnapshotAssetEvent = Extract<AssetEvent, 'xp_awarded' | 'level_up' | 'badge_award'>;
+import type { SnapshotSoundEvent } from '~/types/settings';
 
 export type SnapshotEventDetail = {
-  event: SnapshotAssetEvent;
+  event: SnapshotSoundEvent;
   label: string;
   description: string;
 };
 
-export const SNAPSHOT_AUDIO_EVENT_DETAILS: readonly SnapshotEventDetail[] = [
+export const SNAPSHOT_SOUND_EVENT_DETAILS: readonly SnapshotEventDetail[] = [
   {
-    event: 'xp_awarded',
-    label: 'XP-Phase',
+    event: 'snap_xp',
+    label: 'Snapshot: XP-Animation',
     description: 'Sound, wenn die gewonnenen XP im Snapshot eingeblendet werden.',
   },
   {
-    event: 'level_up',
-    label: 'Level-Phase',
+    event: 'snap_level',
+    label: 'Snapshot: Level-Change',
     description: 'Sound für Level-Aufstiege innerhalb der Snapshot-Präsentation.',
   },
   {
-    event: 'badge_award',
-    label: 'Badge-Phase',
+    event: 'snap_avatar',
+    label: 'Snapshot: Avatar-Entwicklung',
+    description: 'Sound, wenn der Avatar eine Stufe hochspringt.',
+  },
+  {
+    event: 'snap_badge',
+    label: 'Snapshot: Badge-Einblendung',
     description: 'Sound, wenn neue Badges im Snapshot vorgestellt werden.',
   },
 ] as const;
 
-export const SNAPSHOT_AUDIO_EVENTS: readonly SnapshotAssetEvent[] = SNAPSHOT_AUDIO_EVENT_DETAILS.map(
-  (entry) => entry.event,
-);
+export const SNAPSHOT_SOUND_EVENTS: readonly SnapshotSoundEvent[] =
+  SNAPSHOT_SOUND_EVENT_DETAILS.map((entry) => entry.event);
 
-export const isSnapshotAssetEvent = (value: AssetEvent): value is SnapshotAssetEvent =>
-  SNAPSHOT_AUDIO_EVENTS.includes(value as SnapshotAssetEvent);
+export const isSnapshotSoundEvent = (value: string): value is SnapshotSoundEvent =>
+  SNAPSHOT_SOUND_EVENTS.includes(value as SnapshotSoundEvent);

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -1,7 +1,11 @@
 import { DEFAULT_SETTINGS } from './config';
 import { processAward } from './gameLogic';
 import { levelFromXP } from './xp';
-import { sanitizeAssetSettings } from '~/types/settings';
+import {
+  sanitizeAssetSettings,
+  sanitizeSnapshotSoundSettings,
+  sanitizeSoundSettings,
+} from '~/types/settings';
 import type {
   AppState,
   ID,
@@ -70,7 +74,7 @@ export const createInitialState = (
   quests: [],
   logs: [],
   settings: (() => {
-    const { flags, assets, ...restSettings } = settings ?? {};
+    const { flags, assets, sounds, snapshotSounds, ...restSettings } = settings ?? {};
     return {
       ...DEFAULT_SETTINGS,
       ...restSettings,
@@ -79,6 +83,11 @@ export const createInitialState = (
         ...((flags ?? {}) as Record<string, boolean>),
       },
       assets: sanitizeAssetSettings(assets ?? DEFAULT_SETTINGS.assets),
+      sounds: sanitizeSoundSettings(sounds ?? DEFAULT_SETTINGS.sounds, DEFAULT_SETTINGS.sounds),
+      snapshotSounds: sanitizeSnapshotSoundSettings(
+        snapshotSounds ?? DEFAULT_SETTINGS.snapshotSounds,
+        DEFAULT_SETTINGS.snapshotSounds,
+      ),
     } satisfies Settings;
   })(),
   version,

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,6 +1,6 @@
-import type { AssetSettings } from './settings';
+import type { AssetSettings, SnapshotSoundSettings, SoundSettings } from './settings';
 
-export type { AssetEvent, AssetRef, AssetSettings } from './settings';
+export type { AssetEvent, AssetRef, AssetSettings, SnapshotSoundSettings, SoundSettings } from './settings';
 
 export type ID = string;
 
@@ -88,6 +88,8 @@ export type Settings = {
   classMilestoneStep?: number;
   classStarsName?: string;
   assets: AssetSettings;
+  sounds: SoundSettings;
+  snapshotSounds: SnapshotSoundSettings;
 };
 
 export type BadgeDefinition = {

--- a/classquest/src/ui/show/WeeklyShowPlayer.tsx
+++ b/classquest/src/ui/show/WeeklyShowPlayer.tsx
@@ -3,6 +3,7 @@ import { useApp } from '~/app/AppContext';
 import WeeklyShowSlide from '~/ui/show/WeeklyShowSlide';
 import { computeDeltasFromSnapshot, computeWeeklyDeltas, type WeeklyDelta } from '~/core/show/weekly';
 import { listSnapshots, type WeeklySnapshot } from '~/services/weeklyStorage';
+import { preloadSounds } from '~/utils/sounds';
 
 function formatDateLabel(snapshot: WeeklySnapshot): string {
   const created = new Date(snapshot.createdAt);
@@ -52,6 +53,10 @@ export default function WeeklyShowPlayer() {
       return () => window.removeEventListener('storage', handleStorage);
     }
     return () => undefined;
+  }, []);
+
+  React.useEffect(() => {
+    void preloadSounds();
   }, []);
 
   React.useEffect(() => {

--- a/classquest/src/ui/show/WeeklyShowSlide.tsx
+++ b/classquest/src/ui/show/WeeklyShowSlide.tsx
@@ -3,7 +3,7 @@ import { useApp } from '~/app/AppContext';
 import { AvatarView } from '~/ui/avatar/AvatarView';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import EvolutionSequence from '~/ui/show/EvolutionSequence';
-import { playEventAudio } from '~/utils/effects';
+import { playSnapshotSound } from '~/utils/sounds';
 import type { WeeklyDelta } from '~/core/show/weekly';
 
 const AVATAR_SIZE = 220;
@@ -60,13 +60,20 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
       return;
     }
     if (phase === 'xp' && xpGain > 0) {
-      playEventAudio('xp_awarded');
-    } else if (phase === 'level' && levelGain > 0) {
-      playEventAudio('level_up');
-    } else if (phase === 'badges' && hasNewBadges) {
-      playEventAudio('badge_award');
+      void playSnapshotSound('snap_xp');
     }
-  }, [hasNewBadges, levelGain, phase, studentId, xpGain]);
+    if (phase === 'level') {
+      if (levelGain > 0) {
+        void playSnapshotSound('snap_level');
+      }
+      if (evolved) {
+        void playSnapshotSound('snap_avatar');
+      }
+    }
+    if (phase === 'badges' && hasNewBadges) {
+      void playSnapshotSound('snap_badge');
+    }
+  }, [evolved, hasNewBadges, levelGain, phase, studentId, xpGain]);
 
   if (!student) {
     return (

--- a/classquest/src/utils/sounds.ts
+++ b/classquest/src/utils/sounds.ts
@@ -1,0 +1,204 @@
+import type { Settings } from '~/types/models';
+import type {
+  AppSoundEvent,
+  SnapshotSoundEvent,
+  SnapshotSoundSettings,
+  SoundSettings,
+} from '~/types/settings';
+import {
+  cloneSnapshotSoundSettings,
+  cloneSoundSettings,
+  createDefaultSnapshotSoundSettings,
+  createDefaultSoundSettings,
+} from '~/types/settings';
+import { blobStore } from '~/utils/blobStore';
+
+const urlCache = new Map<string, string>();
+const pendingUrls = new Map<string, Promise<string | null>>();
+const assetKeyIndex = new Map<string, string>();
+const lastAtApp = new Map<AppSoundEvent, number>();
+const lastAtSnap = new Map<SnapshotSoundEvent, number>();
+
+let appCfg: SoundSettings = createDefaultSoundSettings();
+let snapCfg: SnapshotSoundSettings = createDefaultSnapshotSoundSettings();
+
+const APP_EVENT_COOLDOWN_MS = 200;
+
+const getNow = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const normalizeKey = (key?: string | null): string | undefined => {
+  if (typeof key !== 'string') return undefined;
+  const trimmed = key.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
+const resolveBindingKey = (binding?: string | null): string | undefined => {
+  const normalized = normalizeKey(binding);
+  if (!normalized) return undefined;
+  return assetKeyIndex.get(normalized) ?? normalized;
+};
+
+const fetchUrlForKey = async (key: string): Promise<string | null> => {
+  const cached = urlCache.get(key);
+  if (cached) return cached;
+  const pending = pendingUrls.get(key);
+  if (pending) return pending;
+  const promise = blobStore
+    .getObjectUrl(key)
+    .then((url) => {
+      if (url) {
+        urlCache.set(key, url);
+        return url;
+      }
+      urlCache.delete(key);
+      return null;
+    })
+    .finally(() => {
+      pendingUrls.delete(key);
+    });
+  pendingUrls.set(key, promise);
+  return promise;
+};
+
+const preloadAudio = async (url: string): Promise<void> => {
+  if (typeof window === 'undefined') return;
+  const AudioCtor = typeof Audio === 'function' ? Audio : undefined;
+  if (!AudioCtor) return;
+  await new Promise<void>((resolve) => {
+    try {
+      const audio = new AudioCtor();
+      audio.preload = 'auto';
+      const finalize = () => {
+        audio.removeEventListener('canplaythrough', finalize);
+        audio.removeEventListener('error', finalize);
+        resolve();
+      };
+      audio.addEventListener('canplaythrough', finalize, { once: true });
+      audio.addEventListener('error', finalize, { once: true });
+      audio.src = url;
+      if (typeof audio.load === 'function') {
+        try {
+          audio.load();
+        } catch {
+          resolve();
+        }
+      }
+    } catch {
+      resolve();
+    }
+  });
+};
+
+const beep = (vol = 1) => {
+  if (typeof window === 'undefined') return;
+  const Ctor =
+    window.AudioContext || (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (typeof Ctor !== 'function') return;
+  try {
+    const ctx = new Ctor();
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+    oscillator.type = 'sine';
+    oscillator.frequency.value = 880;
+    gain.gain.value = Math.max(0, Math.min(1, vol)) * 0.1;
+    oscillator.connect(gain).connect(ctx.destination);
+    oscillator.start();
+    setTimeout(() => {
+      oscillator.stop();
+      ctx.close().catch(() => undefined);
+    }, 120);
+  } catch (error) {
+    console.warn('Snapshot beep failed', error);
+  }
+};
+
+const playByKey = async (binding: string | undefined, volume = 1): Promise<boolean> => {
+  if (typeof window === 'undefined') return false;
+  const resolvedKey = resolveBindingKey(binding);
+  if (!resolvedKey) return false;
+  const url = await fetchUrlForKey(resolvedKey);
+  if (!url) return false;
+  const AudioCtor = typeof Audio === 'function' ? Audio : undefined;
+  if (!AudioCtor) return false;
+  try {
+    const audio = new AudioCtor(url);
+    audio.volume = Math.max(0, Math.min(1, volume));
+    await audio.play();
+    return true;
+  } catch (error) {
+    console.warn('Failed to play snapshot sound', error);
+    return false;
+  }
+};
+
+const collectBindingKeys = (bindings: Partial<Record<string, string | undefined>>): string[] => {
+  const result: string[] = [];
+  Object.values(bindings).forEach((binding) => {
+    const resolved = resolveBindingKey(binding);
+    if (resolved) {
+      result.push(resolved);
+    }
+  });
+  return result;
+};
+
+const updateAssetIndex = (settings: Settings | null | undefined) => {
+  assetKeyIndex.clear();
+  const library = settings?.assets?.library ?? {};
+  Object.entries(library).forEach(([id, ref]) => {
+    if (!ref) return;
+    const key = normalizeKey(ref.key) ?? normalizeKey(id);
+    if (!key) return;
+    assetKeyIndex.set(id, key);
+    assetKeyIndex.set(key, key);
+  });
+};
+
+export function setSoundSettings(settings: Settings | null | undefined): void {
+  appCfg = cloneSoundSettings(settings?.sounds);
+  snapCfg = cloneSnapshotSoundSettings(settings?.snapshotSounds);
+  updateAssetIndex(settings);
+  lastAtApp.clear();
+  lastAtSnap.clear();
+}
+
+export async function preloadSounds(): Promise<void> {
+  const keys = new Set<string>();
+  collectBindingKeys(appCfg.bindings ?? {}).forEach((key) => keys.add(key));
+  collectBindingKeys(snapCfg.bindings ?? {}).forEach((key) => keys.add(key));
+  if (!keys.size) return;
+  await Promise.all(
+    Array.from(keys).map(async (key) => {
+      const url = await fetchUrlForKey(key);
+      if (!url) return;
+      await preloadAudio(url);
+    }),
+  );
+}
+
+export async function playSound(evt: AppSoundEvent): Promise<void> {
+  if (!appCfg.enabled) return;
+  const now = getNow();
+  if ((lastAtApp.get(evt) ?? 0) > now - APP_EVENT_COOLDOWN_MS) return;
+  const key = appCfg.bindings?.[evt];
+  const played = await playByKey(key, appCfg.masterVolume);
+  if (!played && appCfg.useFallbackBeep) {
+    beep(appCfg.masterVolume);
+  }
+  lastAtApp.set(evt, now);
+}
+
+export async function playSnapshotSound(evt: SnapshotSoundEvent): Promise<void> {
+  if (!snapCfg.enabled) return;
+  const now = getNow();
+  const cooldown = snapCfg.cooldownMs?.[evt] ?? APP_EVENT_COOLDOWN_MS;
+  if ((lastAtSnap.get(evt) ?? 0) > now - cooldown) return;
+  const key = snapCfg.bindings?.[evt];
+  await playByKey(key, snapCfg.volume);
+  lastAtSnap.set(evt, now);
+}

--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { processAward } from '~/core/gameLogic';
 import type { AppState, Quest, Student } from '~/types/models';
-import { createDefaultAssetSettings } from '~/types/settings';
+import {
+  createDefaultAssetSettings,
+  createDefaultSnapshotSoundSettings,
+  createDefaultSoundSettings,
+} from '~/types/settings';
 
 const createStudent = (overrides: Partial<Student> = {}): Student => ({
   id: 'student-1',
@@ -29,6 +33,8 @@ const createState = (studentOverrides: Partial<Student> = {}): AppState => {
       streakThresholdForBadge: 2,
       allowNegativeXP: false,
       assets: createDefaultAssetSettings(),
+      sounds: createDefaultSoundSettings(),
+      snapshotSounds: createDefaultSnapshotSoundSettings(),
     },
     version: 1,
     classProgress: { totalXP, stars: Math.floor(totalXP / 1000) },
@@ -100,6 +106,8 @@ describe('processAward', () => {
         streakThresholdForBadge: 2,
         allowNegativeXP: true,
         assets: createDefaultAssetSettings(),
+        sounds: createDefaultSoundSettings(),
+        snapshotSounds: createDefaultSnapshotSoundSettings(),
       },
     } satisfies AppState;
 

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalStorageAdapter, STORAGE_KEY } from '~/services/storage/localStorage';
 import type { AppState } from '~/types/models';
 import { sanitizeState } from '~/core/schema/appState';
-import { createDefaultAssetSettings } from '~/types/settings';
+import {
+  createDefaultAssetSettings,
+  createDefaultSnapshotSoundSettings,
+  createDefaultSoundSettings,
+} from '~/types/settings';
 
 type GlobalWithStorage = typeof globalThis & { localStorage?: Storage };
 
@@ -45,6 +49,8 @@ const sampleState = (): AppState => ({
     streakThresholdForBadge: 5,
     allowNegativeXP: false,
     assets: createDefaultAssetSettings(),
+    sounds: createDefaultSoundSettings(),
+    snapshotSounds: createDefaultSnapshotSoundSettings(),
   },
   version: 1,
   classProgress: { totalXP: 10, stars: 0 },


### PR DESCRIPTION
## Summary
- extend settings/types with dedicated snapshot sound configuration and defaults
- add runtime helpers to preload and play snapshot sounds separately from app audio
- update management UI and weekly show to configure and trigger the new snapshot sounds

## Testing
- npm run test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d2b30e6514832ca848ce05ef88d7a4