### PR TITLE
Use coalesced XP award effects

### DIFF
--- a/classquest/src/ui/screens/AwardScreen.tsx
+++ b/classquest/src/ui/screens/AwardScreen.tsx
@@ -9,7 +9,7 @@ import { EVENT_CLEAR_SELECTION, EVENT_SELECT_ALL, EVENT_FOCUS_STUDENT, EVENT_SET
 import { useFeedback } from '~/ui/feedback/FeedbackProvider';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { Quest, Team } from '~/types/models';
-import { playSound } from '~/utils/sounds';
+import { playXpAwardedEffectsCoalesced } from '~/utils/effects';
 import { playLottieOverlay } from '~/ui/anim/playLottie';
 
 const TILE_MIN_WIDTH = 240;
@@ -253,7 +253,7 @@ export default function AwardScreen() {
   const awardStudent = useCallback(
     (studentId: string, quest: Quest) => {
       dispatch({ type: 'AWARD', payload: { questId: quest.id, studentId } });
-      void playSound('xp_awarded');
+      playXpAwardedEffectsCoalesced();
     },
     [dispatch],
   );
@@ -300,7 +300,7 @@ export default function AwardScreen() {
       if (!team) return;
       if (activeQuest.target === 'team') {
         dispatch({ type: 'AWARD', payload: { questId: activeQuest.id, teamId: team.id } });
-        void playSound('xp_awarded');
+        playXpAwardedEffectsCoalesced();
         showUndoToast(activeQuest, team.name);
         feedback.success(`${activeQuest.name} an ${team.name}`);
         return;


### PR DESCRIPTION
## Summary
- use the shared xp award effects helper when students or teams receive awards so sounds coalesce
- remove the unused direct sound effect import from the award screen

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2d1d451ac832cbe8fa900d777dbb3