### PR TITLE
Simplify snapshot sound management

### DIFF
--- a/classquest/src/components/manage/AssetBindingRow.tsx
+++ b/classquest/src/components/manage/AssetBindingRow.tsx
@@ -1,4 +1,4 @@
-import type { AssetEvent } from '~/types/settings';
+import type { SnapshotSoundEvent } from '~/types/settings';
 
 type AssetOption = {
   id: string;
@@ -6,15 +6,13 @@ type AssetOption = {
 };
 
 type AssetBindingRowProps = {
-  event: AssetEvent;
+  event: SnapshotSoundEvent;
   label: string;
   description: string;
   audioOptions: AssetOption[];
-  lottieOptions: AssetOption[];
   audioValue?: string | null;
-  lottieValue?: string | null;
-  onChange: (kind: 'audio' | 'lottie', event: AssetEvent, key: string | null) => void;
-  onTest: (event: AssetEvent) => void;
+  onChange: (event: SnapshotSoundEvent, key: string | null) => void;
+  onTest: (event: SnapshotSoundEvent) => void;
 };
 
 export default function AssetBindingRow({
@@ -22,13 +20,11 @@ export default function AssetBindingRow({
   label,
   description,
   audioOptions,
-  lottieOptions,
   audioValue,
-  lottieValue,
   onChange,
   onTest,
 }: AssetBindingRowProps) {
-  const canTest = Boolean(audioValue) || Boolean(lottieValue);
+  const canTest = Boolean(audioValue);
 
   return (
     <tr>
@@ -41,27 +37,12 @@ export default function AssetBindingRow({
       <td style={{ padding: '10px 8px' }}>
         <select
           value={audioValue ?? ''}
-          onChange={(changeEvent) => onChange('audio', assetEvent, changeEvent.target.value || null)}
+          onChange={(changeEvent) => onChange(assetEvent, changeEvent.target.value || null)}
           aria-label={`Audio-Binding für ${label}`}
           style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5f5', minWidth: 160 }}
         >
           <option value="">– Kein Audio –</option>
           {audioOptions.map((option) => (
-            <option key={option.id} value={option.id}>
-              {option.name}
-            </option>
-          ))}
-        </select>
-      </td>
-      <td style={{ padding: '10px 8px' }}>
-        <select
-          value={lottieValue ?? ''}
-          onChange={(changeEvent) => onChange('lottie', assetEvent, changeEvent.target.value || null)}
-          aria-label={`Animations-Binding für ${label}`}
-          style={{ padding: '6px 8px', borderRadius: 8, border: '1px solid #cbd5f5', minWidth: 160 }}
-        >
-          <option value="">– Keine Animation –</option>
-          {lottieOptions.map((option) => (
             <option key={option.id} value={option.id}>
               {option.name}
             </option>

--- a/classquest/src/screens/manage/AssetsTab.tsx
+++ b/classquest/src/screens/manage/AssetsTab.tsx
@@ -5,18 +5,17 @@ import AssetUploadCard from '~/components/manage/AssetUploadCard';
 import AssetPreviewList from '~/components/manage/AssetPreviewList';
 import AssetBindingRow from '~/components/manage/AssetBindingRow';
 import { blobStore } from '~/utils/blobStore';
-import { triggerEventLottie, preloadAssets } from '~/utils/effects';
 import { playSnapshotSound, preloadSounds } from '~/utils/sounds';
 import {
-  type AssetEvent,
   type AssetKind,
   type AssetSettings,
   cloneAssetSettings,
   cloneSnapshotSoundSettings,
   createDefaultAssetSettings,
   createDefaultSnapshotSoundSettings,
+  type SnapshotSoundEvent,
 } from '~/types/settings';
-import { SNAPSHOT_SOUND_EVENT_DETAILS, isSnapshotSoundEvent } from '~/core/show/snapshotEvents';
+import { SNAPSHOT_SOUND_EVENT_DETAILS } from '~/core/show/snapshotEvents';
 
 const AUDIO_TYPES = new Set([
   'audio/mpeg',
@@ -27,18 +26,7 @@ const AUDIO_TYPES = new Set([
   'audio/x-pn-wav',
 ]);
 
-const IMAGE_TYPES = new Set([
-  'image/png',
-  'image/jpeg',
-  'image/jpg',
-  'image/webp',
-  'image/svg+xml',
-]);
-
-const LOTTIE_TYPES = new Set(['application/json']);
-
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
-const MAX_LOTTIE_BYTES = 200 * 1024;
 
 const fileMatches = (file: File, types: Set<string>, extensions: string[]): boolean => {
   if (file.type && types.has(file.type.toLowerCase())) {
@@ -50,17 +38,12 @@ const fileMatches = (file: File, types: Set<string>, extensions: string[]): bool
 
 const createAssetKey = () => `asset:${globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
 
-const toPercent = (value: number | undefined) => Math.round((Math.max(0, Math.min(1, value ?? 1))) * 100);
-
-const fromPercent = (value: number) => Math.max(0, Math.min(1, value / 100));
-
 export default function AssetsTab() {
   const { state, dispatch } = useApp();
   const feedback = useFeedback();
   const assets = state.settings.assets ?? createDefaultAssetSettings();
   const snapshotSounds =
     state.settings.snapshotSounds ?? createDefaultSnapshotSoundSettings();
-  const [preloadingAssets, setPreloadingAssets] = useState(false);
   const [preloadingSnapshotSounds, setPreloadingSnapshotSounds] = useState(false);
 
   const updateAssets = (updater: (draft: AssetSettings) => void, message?: string) => {
@@ -99,37 +82,12 @@ export default function AssetsTab() {
     [libraryEntries],
   );
 
-  const lottieOptions = useMemo(
-    () => libraryEntries.filter(({ ref }) => ref.type === 'lottie').map(({ id, ref }) => ({ id, name: ref.name })),
-    [libraryEntries],
-  );
-
   const validateAudio = (file: File) => {
     if (!fileMatches(file, AUDIO_TYPES, ['.mp3', '.ogg', '.wav'])) {
       return 'Ungültiger Dateityp. Bitte MP3, OGG oder WAV verwenden.';
     }
     if (file.size > MAX_FILE_BYTES) {
       return 'Datei ist zu groß (max. 2 MB).';
-    }
-    return null;
-  };
-
-  const validateImage = (file: File) => {
-    if (!fileMatches(file, IMAGE_TYPES, ['.png', '.jpg', '.jpeg', '.webp', '.svg'])) {
-      return 'Ungültiger Dateityp. Bitte PNG, JPG, WEBP oder SVG verwenden.';
-    }
-    if (file.size > MAX_FILE_BYTES) {
-      return 'Datei ist zu groß (max. 2 MB).';
-    }
-    return null;
-  };
-
-  const validateLottie = (file: File) => {
-    if (!fileMatches(file, LOTTIE_TYPES, ['.json'])) {
-      return 'Ungültiger Dateityp. Bitte Lottie-JSON verwenden.';
-    }
-    if (file.size > MAX_LOTTIE_BYTES) {
-      return 'Animation ist sehr groß (empfohlen < 500 KB).';
     }
     return null;
   };
@@ -181,52 +139,18 @@ export default function AssetsTab() {
     feedback.success('Asset entfernt');
   };
 
-  const handleBindingChange = (kind: 'audio' | 'lottie', event: AssetEvent, key: string | null) => {
-    if (kind === 'audio') {
-      if (!isSnapshotSoundEvent(event)) {
-        return;
-      }
-      updateSnapshotSounds((draft) => {
-        if (key) {
-          draft.bindings[event] = key;
-        } else {
-          delete draft.bindings[event];
-        }
-      }, 'Snapshot-Sound gespeichert');
-      return;
-    }
-    if (!isSnapshotSoundEvent(event)) {
-      return;
-    }
-    updateAssets((draft) => {
+  const handleBindingChange = (event: SnapshotSoundEvent, key: string | null) => {
+    updateSnapshotSounds((draft) => {
       if (key) {
-        draft.bindings.lottie[event] = key;
+        draft.bindings[event] = key;
       } else {
-        delete draft.bindings.lottie[event];
+        delete draft.bindings[event];
       }
-    }, 'Verknüpfung gespeichert');
+    }, 'Snapshot-Sound gespeichert');
   };
 
-  const handleTest = (event: AssetEvent) => {
-    if (!isSnapshotSoundEvent(event)) {
-      return;
-    }
+  const handleTest = (event: SnapshotSoundEvent) => {
     void playSnapshotSound(event);
-    triggerEventLottie(event, { center: true });
-  };
-
-  const handleAssetPreload = async () => {
-    if (preloadingAssets) return;
-    setPreloadingAssets(true);
-    try {
-      await preloadAssets();
-      feedback.success('Assets vorgeladen');
-    } catch (error) {
-      console.error('Preload fehlgeschlagen', error);
-      feedback.error('Preload fehlgeschlagen');
-    } finally {
-      setPreloadingAssets(false);
-    }
   };
 
   const handleSnapshotPreload = async () => {
@@ -243,10 +167,6 @@ export default function AssetsTab() {
     }
   };
 
-  const audioEnabled = assets.audio?.enabled ?? true;
-  const animationEnabled = assets.animations?.enabled ?? true;
-  const reducedMotion = assets.animations?.preferReducedMotion ?? false;
-  const volumePercent = toPercent(assets.audio?.masterVolume);
   const snapshotVolumePercent = Math.round(
     Math.max(0, Math.min(1, snapshotSounds.volume ?? 1)) * 100,
   );
@@ -270,35 +190,19 @@ export default function AssetsTab() {
             validate={validateAudio}
             onUpload={(file) => handleUpload(file, 'audio')}
           />
-          <AssetUploadCard
-            title="Lottie-Animation hochladen"
-            description="Animationsdatei im JSON-Format."
-            accept=".json"
-            hint="Bitte Lottie-JSON hochladen (optimiert, &lt;500 KB empfohlen)."
-            validate={validateLottie}
-            onUpload={(file) => handleUpload(file, 'lottie')}
-          />
-          <AssetUploadCard
-            title="Grafik hochladen"
-            description="Bilder für Avatare, Badges oder Klassenstars."
-            accept=".png,.jpg,.jpeg,.webp,.svg"
-            hint="Bitte PNG, JPG, WEBP oder SVG hochladen (max. 2 MB)."
-            validate={validateImage}
-            onUpload={(file) => handleUpload(file, 'image')}
-          />
         </div>
       </section>
 
       <AssetPreviewList assets={libraryEntries} onRename={handleRename} onDelete={handleDelete} />
 
       <section style={{ display: 'grid', gap: 16 }} aria-label="Snapshot-Sounds">
-        <div style={{ display: 'grid', gap: 4 }}>
-          <h2 style={{ margin: 0, fontSize: 20 }}>Snapshot-Sounds</h2>
-          <p style={{ margin: 0, color: '#475569' }}>
-            Lege fest, welche Audioeffekte während der Snapshot-Show für XP, Level, Avatar und Badges
-            abgespielt werden. Optional kannst du hier auch passende Animationen zuordnen.
-          </p>
-        </div>
+          <div style={{ display: 'grid', gap: 4 }}>
+            <h2 style={{ margin: 0, fontSize: 20 }}>Snapshot-Sounds</h2>
+            <p style={{ margin: 0, color: '#475569' }}>
+              Lege fest, welche Audioeffekte während der Snapshot-Show für XP, Level, Avatar und Badges
+              abgespielt werden.
+            </p>
+          </div>
         <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <input
             type="checkbox"
@@ -335,7 +239,6 @@ export default function AssetsTab() {
               <tr>
                 <th style={{ textAlign: 'left', padding: '8px' }}>Event</th>
                 <th style={{ textAlign: 'left', padding: '8px' }}>Audio</th>
-                <th style={{ textAlign: 'left', padding: '8px' }}>Animation</th>
                 <th style={{ textAlign: 'left', padding: '8px' }}>Test</th>
               </tr>
             </thead>
@@ -347,9 +250,7 @@ export default function AssetsTab() {
                   label={label}
                   description={description}
                   audioOptions={audioOptions}
-                  lottieOptions={lottieOptions}
                   audioValue={snapshotSounds.bindings?.[event] ?? null}
-                  lottieValue={assets.bindings?.lottie?.[event] ?? null}
                   onChange={handleBindingChange}
                   onTest={handleTest}
                 />
@@ -377,80 +278,6 @@ export default function AssetsTab() {
         </div>
       </section>
 
-      <section style={{ display: 'grid', gap: 16 }} aria-label="Globale Einstellungen">
-        <h2 style={{ margin: 0, fontSize: 20 }}>Globale Einstellungen</h2>
-        <div style={{ display: 'grid', gap: 12 }}>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <input
-              type="checkbox"
-              checked={audioEnabled}
-              onChange={(event) =>
-                updateAssets((draft) => {
-                  draft.audio.enabled = event.target.checked;
-                }, event.target.checked ? 'Audio aktiviert' : 'Audio deaktiviert')
-              }
-            />
-            Audio aktiv
-          </label>
-          <label style={{ display: 'grid', gap: 6, maxWidth: 320 }}>
-            <span>Master-Volume: {volumePercent}%</span>
-            <input
-              type="range"
-              min={0}
-              max={100}
-              value={volumePercent}
-              onChange={(event) => {
-                const value = Number.parseInt(event.target.value, 10) || 0;
-                updateAssets((draft) => {
-                  draft.audio.masterVolume = fromPercent(value);
-                });
-              }}
-            />
-          </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <input
-              type="checkbox"
-              checked={animationEnabled}
-              onChange={(event) =>
-                updateAssets((draft) => {
-                  draft.animations.enabled = event.target.checked;
-                }, event.target.checked ? 'Animationen aktiviert' : 'Animationen deaktiviert')
-              }
-            />
-            Animationen aktiv
-          </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-            <input
-              type="checkbox"
-              checked={reducedMotion}
-              onChange={(event) =>
-                updateAssets((draft) => {
-                  draft.animations.preferReducedMotion = event.target.checked;
-                }, event.target.checked ? 'Reduzierte Bewegung bevorzugt' : 'Volle Bewegung bevorzugt')
-              }
-            />
-            Reduzierte Bewegungen bevorzugen
-          </label>
-        </div>
-        <div>
-          <button
-            type="button"
-            onClick={handleAssetPreload}
-            disabled={preloadingAssets}
-            style={{
-              padding: '8px 16px',
-              borderRadius: 10,
-              border: '1px solid #38bdf8',
-              backgroundColor: preloadingAssets ? '#bae6fd' : '#e0f2fe',
-              color: '#0f172a',
-              fontWeight: 600,
-              cursor: preloadingAssets ? 'progress' : 'pointer',
-            }}
-          >
-            {preloadingAssets ? 'Lädt…' : 'Alle Assets preladen'}
-          </button>
-        </div>
-      </section>
     </div>
   );
 }

--- a/classquest/src/ui/feedback/FeedbackProvider.tsx
+++ b/classquest/src/ui/feedback/FeedbackProvider.tsx
@@ -16,33 +16,6 @@ const makeId = () => globalThis.crypto?.randomUUID?.() ?? Math.random().toString
 const makeToast = (kind: Toast['kind'], message: string): Toast => ({ id: makeId(), kind, message, t: Date.now() });
 
 function useSfx(enabled: boolean) {
-  const playFallbackTone = useCallback((kind: 'success' | 'error') => {
-    if (typeof window === 'undefined') return;
-    try {
-      const withWebkit = window as typeof window & { webkitAudioContext?: typeof window.AudioContext };
-      const AudioContextCtor = withWebkit.AudioContext ?? withWebkit.webkitAudioContext;
-      if (!AudioContextCtor) return;
-      const ctx = new AudioContextCtor();
-      const osc = ctx.createOscillator();
-      const gain = ctx.createGain();
-      osc.type = 'sine';
-      const now = ctx.currentTime;
-      const fStart = kind === 'success' ? 880 : 220;
-      const fEnd = kind === 'success' ? 1320 : 110;
-      osc.frequency.setValueAtTime(fStart, now);
-      osc.frequency.exponentialRampToValueAtTime(fEnd, now + 0.12);
-      gain.gain.setValueAtTime(0.0001, now);
-      gain.gain.exponentialRampToValueAtTime(0.08, now + 0.02);
-      gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.16);
-      osc.connect(gain).connect(ctx.destination);
-      osc.start(now);
-      osc.stop(now + 0.18);
-      setTimeout(() => void ctx.close(), 250);
-    } catch (error) {
-      console.warn('Feedback sound failed', error);
-    }
-  }, []);
-
   const play = useCallback(
     (kind: 'success' | 'error') => {
       if (!enabled || typeof window === 'undefined') return;
@@ -51,9 +24,9 @@ function useSfx(enabled: boolean) {
       if (result === 'played' || result === 'cooldown' || result === 'disabled') {
         return;
       }
-      playFallbackTone(kind);
+      // No fallback tone – only play configured UI sounds.
     },
-    [enabled, playFallbackTone],
+    [enabled],
   );
   return play;
 }


### PR DESCRIPTION
## Summary
- streamline the snapshot sound settings by focusing the asset upload and binding UI on audio-only slideshow events
- simplify the asset binding row to audio-only controls and update copy to match the trimmed configuration
- remove the UI sound fallback tone so only configured snapshot and UI audio plays

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d566292fac832c9a885e7836e22350