### PR TITLE
Refactor sound system to support curated events

### DIFF
--- a/classquest/src/__tests__/badges.autorules.test.ts
+++ b/classquest/src/__tests__/badges.autorules.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { selectStudentCategoryXp, shouldAutoAward } from '~/core/selectors/badges';
 import type { AppState, Student, BadgeDefinition } from '~/types/models';
-import {
-  createDefaultAssetSettings,
-  createDefaultSnapshotSoundSettings,
-  createDefaultSoundSettings,
-} from '~/types/settings';
+import { createDefaultAssetSettings, createDefaultSoundSettings } from '~/types/settings';
 
 type Mutable<T> = {
   -readonly [K in keyof T]: T[K];
@@ -97,7 +93,6 @@ const baseState: Mutable<AppState> = {
     classStarsName: 'Stern',
     assets: createDefaultAssetSettings(),
     sounds: createDefaultSoundSettings(),
-    snapshotSounds: createDefaultSnapshotSoundSettings(),
   },
   version: 1,
   classProgress: { totalXP: 0, stars: 0 },

--- a/classquest/src/components/manage/AssetBindingRow.tsx
+++ b/classquest/src/components/manage/AssetBindingRow.tsx
@@ -1,4 +1,4 @@
-import type { SnapshotSoundEvent } from '~/types/settings';
+import type { AppSoundEvent } from '~/types/settings';
 
 type AssetOption = {
   id: string;
@@ -6,13 +6,13 @@ type AssetOption = {
 };
 
 type AssetBindingRowProps = {
-  event: SnapshotSoundEvent;
+  event: AppSoundEvent;
   label: string;
   description: string;
   audioOptions: AssetOption[];
   audioValue?: string | null;
-  onChange: (event: SnapshotSoundEvent, key: string | null) => void;
-  onTest: (event: SnapshotSoundEvent) => void;
+  onChange: (event: AppSoundEvent, key: string | null) => void;
+  onTest: (event: AppSoundEvent) => void;
 };
 
 export default function AssetBindingRow({

--- a/classquest/src/core/config.ts
+++ b/classquest/src/core/config.ts
@@ -1,5 +1,5 @@
 import type { Settings } from '~/types/models';
-import { createDefaultAssetSettings, createDefaultSnapshotSoundSettings, createDefaultSoundSettings } from '~/types/settings';
+import { createDefaultAssetSettings, createDefaultSoundSettings } from '~/types/settings';
 export const DEFAULT_SETTINGS: Required<Settings> = {
   className: 'Meine Klasse',
   xpPerLevel: 100,
@@ -18,5 +18,4 @@ export const DEFAULT_SETTINGS: Required<Settings> = {
   classStarsName: 'Stern',
   assets: createDefaultAssetSettings(),
   sounds: createDefaultSoundSettings(),
-  snapshotSounds: createDefaultSnapshotSoundSettings(),
 };

--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -5,10 +5,8 @@ import {
   DEFAULT_LOTTIE_COOLDOWN_MS,
   DEFAULT_XP_COALESCE_WINDOW_MS,
   sanitizeAssetSettings,
-  sanitizeSnapshotSoundSettings,
   sanitizeSoundSettings,
   createDefaultSoundSettings,
-  createDefaultSnapshotSoundSettings,
 } from '~/types/settings';
 
 import { sanitizeAvatarStageThresholds } from '../avatarStages';
@@ -131,25 +129,14 @@ const AssetSettingsSchema = z.object({
 });
 
 const SOUND_SETTINGS_DEFAULT = createDefaultSoundSettings();
-const SNAPSHOT_SOUND_SETTINGS_DEFAULT = createDefaultSnapshotSoundSettings();
 
 const SoundSettingsSchema = z
   .object({
     enabled: z.boolean(),
     masterVolume: z.number(),
-    useFallbackBeep: z.boolean().optional(),
     bindings: z.record(z.string(), z.string()).default({}),
   })
   .default(SOUND_SETTINGS_DEFAULT);
-
-const SnapshotSoundSettingsSchema = z
-  .object({
-    enabled: z.boolean(),
-    volume: z.number(),
-    bindings: z.record(z.string(), z.string()).default({}),
-    cooldownMs: z.record(z.string(), z.number().nonnegative()).optional(),
-  })
-  .default(SNAPSHOT_SOUND_SETTINGS_DEFAULT);
 
 export const Settings = z.object({
   className: z.string(),
@@ -170,7 +157,6 @@ export const Settings = z.object({
   classStarsName: z.string().optional(),
   assets: AssetSettingsSchema,
   sounds: SoundSettingsSchema,
-  snapshotSounds: SnapshotSoundSettingsSchema,
 });
 
 export const ClassProgress = z.object({
@@ -475,10 +461,6 @@ export function sanitizeState(raw: unknown): AppStateType | null {
     settingsRecord.sounds ?? DEFAULT_SETTINGS.sounds,
     DEFAULT_SETTINGS.sounds,
   );
-  const snapshotSounds = sanitizeSnapshotSoundSettings(
-    settingsRecord.snapshotSounds ?? DEFAULT_SETTINGS.snapshotSounds,
-    DEFAULT_SETTINGS.snapshotSounds,
-  );
   const settings: AppStateType['settings'] = {
     className: asString(settingsRecord.className) ?? 'Meine Klasse',
     xpPerLevel: Math.max(1, Math.floor(asNumber(settingsRecord.xpPerLevel, 100)) || 1),
@@ -503,7 +485,6 @@ export function sanitizeState(raw: unknown): AppStateType | null {
     classStarsName: asString(settingsRecord.classStarsName) ?? DEFAULT_SETTINGS.classStarsName,
     assets,
     sounds,
-    snapshotSounds,
   };
 
   const totalXP = Math.max(

--- a/classquest/src/core/show/snapshotEvents.ts
+++ b/classquest/src/core/show/snapshotEvents.ts
@@ -1,36 +1,30 @@
-import type { SnapshotSoundEvent } from '~/types/settings';
+import type { AppSoundEvent } from '~/types/settings';
 
-export type SnapshotEventDetail = {
-  event: SnapshotSoundEvent;
+export type SoundEventDetail = {
+  event: AppSoundEvent;
   label: string;
   description: string;
 };
 
-export const SNAPSHOT_SOUND_EVENT_DETAILS: readonly SnapshotEventDetail[] = [
+export const SOUND_EVENT_DETAILS: readonly SoundEventDetail[] = [
   {
-    event: 'snap_xp',
-    label: 'Snapshot: XP-Animation',
-    description: 'Sound, wenn die gewonnenen XP im Snapshot eingeblendet werden.',
+    event: 'xp_awarded',
+    label: 'XP vergeben',
+    description: 'Spielt ab, wenn XP vergeben werden oder XP-Gewinne im Snapshot erscheinen.',
   },
   {
-    event: 'snap_level',
-    label: 'Snapshot: Level-Change',
-    description: 'Sound für Level-Aufstiege innerhalb der Snapshot-Präsentation.',
+    event: 'level_up',
+    label: 'Level-Up',
+    description: 'Sound für Levelaufstiege in der App und im Snapshot.',
   },
   {
-    event: 'snap_avatar',
-    label: 'Snapshot: Avatar-Entwicklung',
-    description: 'Sound, wenn der Avatar eine Stufe hochspringt.',
+    event: 'badge_award',
+    label: 'Badge vergeben',
+    description: 'Sound, wenn neue Badges verliehen oder im Snapshot gezeigt werden.',
   },
   {
-    event: 'snap_badge',
-    label: 'Snapshot: Badge-Einblendung',
-    description: 'Sound, wenn neue Badges im Snapshot vorgestellt werden.',
+    event: 'showcase_start',
+    label: 'Snapshot/Showcase Start',
+    description: 'Intro-Sound beim Start der Snapshot-Show.',
   },
 ] as const;
-
-export const SNAPSHOT_SOUND_EVENTS: readonly SnapshotSoundEvent[] =
-  SNAPSHOT_SOUND_EVENT_DETAILS.map((entry) => entry.event);
-
-export const isSnapshotSoundEvent = (value: string): value is SnapshotSoundEvent =>
-  SNAPSHOT_SOUND_EVENTS.includes(value as SnapshotSoundEvent);

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -1,11 +1,7 @@
 import { DEFAULT_SETTINGS } from './config';
 import { processAward } from './gameLogic';
 import { levelFromXP } from './xp';
-import {
-  sanitizeAssetSettings,
-  sanitizeSnapshotSoundSettings,
-  sanitizeSoundSettings,
-} from '~/types/settings';
+import { sanitizeAssetSettings, sanitizeSoundSettings } from '~/types/settings';
 import type {
   AppState,
   ID,
@@ -74,7 +70,7 @@ export const createInitialState = (
   quests: [],
   logs: [],
   settings: (() => {
-    const { flags, assets, sounds, snapshotSounds, ...restSettings } = settings ?? {};
+    const { flags, assets, sounds, ...restSettings } = settings ?? {};
     return {
       ...DEFAULT_SETTINGS,
       ...restSettings,
@@ -84,10 +80,6 @@ export const createInitialState = (
       },
       assets: sanitizeAssetSettings(assets ?? DEFAULT_SETTINGS.assets),
       sounds: sanitizeSoundSettings(sounds ?? DEFAULT_SETTINGS.sounds, DEFAULT_SETTINGS.sounds),
-      snapshotSounds: sanitizeSnapshotSoundSettings(
-        snapshotSounds ?? DEFAULT_SETTINGS.snapshotSounds,
-        DEFAULT_SETTINGS.snapshotSounds,
-      ),
     } satisfies Settings;
   })(),
   version,

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -1,6 +1,6 @@
-import type { AssetSettings, SnapshotSoundSettings, SoundSettings } from './settings';
+import type { AssetSettings, SoundSettings } from './settings';
 
-export type { AssetEvent, AssetRef, AssetSettings, SnapshotSoundSettings, SoundSettings } from './settings';
+export type { AssetEvent, AssetRef, AssetSettings, SoundSettings } from './settings';
 
 export type ID = string;
 
@@ -89,7 +89,6 @@ export type Settings = {
   classStarsName?: string;
   assets: AssetSettings;
   sounds: SoundSettings;
-  snapshotSounds: SnapshotSoundSettings;
 };
 
 export type BadgeDefinition = {

--- a/classquest/src/types/settings.ts
+++ b/classquest/src/types/settings.ts
@@ -41,22 +41,12 @@ export interface AssetCooldownSettings {
   coalesceWindowMs?: AssetCooldownMap;
 }
 
-export type AppSoundEvent = 'xp_awarded' | 'level_up' | 'badge_award';
-
-export type SnapshotSoundEvent = 'snap_xp' | 'snap_level' | 'snap_avatar' | 'snap_badge';
+export type AppSoundEvent = 'xp_awarded' | 'level_up' | 'badge_award' | 'showcase_start';
 
 export interface SoundSettings {
   enabled: boolean;
   masterVolume: number;
-  useFallbackBeep?: boolean;
   bindings: Partial<Record<AppSoundEvent, string>>;
-}
-
-export interface SnapshotSoundSettings {
-  enabled: boolean;
-  volume: number;
-  bindings: Partial<Record<SnapshotSoundEvent, string>>;
-  cooldownMs?: Partial<Record<SnapshotSoundEvent, number>>;
 }
 
 export const DEFAULT_AUDIO_COOLDOWN_MS = 250;
@@ -67,22 +57,8 @@ export const APP_SOUND_EVENTS: Readonly<AppSoundEvent[]> = Object.freeze([
   'xp_awarded',
   'level_up',
   'badge_award',
+  'showcase_start',
 ]);
-
-export const SNAPSHOT_SOUND_EVENTS: Readonly<SnapshotSoundEvent[]> = Object.freeze([
-  'snap_xp',
-  'snap_level',
-  'snap_avatar',
-  'snap_badge',
-]);
-
-const DEFAULT_SNAPSHOT_SOUND_COOLDOWNS: Readonly<Record<SnapshotSoundEvent, number>> =
-  Object.freeze({
-    snap_xp: 150,
-    snap_badge: 300,
-    snap_level: 300,
-    snap_avatar: 300,
-  });
 
 const DEFAULT_COALESCE_WINDOW_MAP: Readonly<AssetCooldownMap> = Object.freeze({
   xp_awarded: DEFAULT_XP_COALESCE_WINDOW_MS,
@@ -266,25 +242,6 @@ const sanitizeSoundBindingMap = <T extends string>(
   return result;
 };
 
-const sanitizeSnapshotCooldownMap = (
-  value: unknown,
-  defaults: Partial<Record<SnapshotSoundEvent, number>>,
-): Partial<Record<SnapshotSoundEvent, number>> => {
-  const base: Partial<Record<SnapshotSoundEvent, number>> = { ...defaults };
-  if (typeof value !== 'object' || value === null) {
-    return base;
-  }
-  const result: Partial<Record<SnapshotSoundEvent, number>> = { ...base };
-  Object.entries(value as Record<string, unknown>).forEach(([event, candidate]) => {
-    if (!SNAPSHOT_SOUND_EVENTS.includes(event as SnapshotSoundEvent)) return;
-    const parsed = asNumber(candidate);
-    if (parsed == null) return;
-    const fallback = base[event as SnapshotSoundEvent] ?? 0;
-    result[event as SnapshotSoundEvent] = clampNonNegative(parsed, fallback);
-  });
-  return result;
-};
-
 const sanitizeCooldownSettings = (
   value: unknown,
   defaults: AssetCooldownSettings | undefined,
@@ -372,34 +329,13 @@ export const sanitizeAssetSettings = (value: unknown): AssetSettings => {
 export const createDefaultSoundSettings = (): SoundSettings => ({
   enabled: true,
   masterVolume: 1,
-  useFallbackBeep: false,
   bindings: {},
-});
-
-export const createDefaultSnapshotSoundSettings = (): SnapshotSoundSettings => ({
-  enabled: true,
-  volume: 1,
-  bindings: {},
-  cooldownMs: { ...DEFAULT_SNAPSHOT_SOUND_COOLDOWNS },
 });
 
 export const cloneSoundSettings = (settings: SoundSettings | undefined): SoundSettings => ({
   enabled: settings?.enabled ?? true,
   masterVolume: clamp01(settings?.masterVolume, 1),
-  useFallbackBeep: settings?.useFallbackBeep ?? false,
   bindings: { ...(settings?.bindings ?? {}) },
-});
-
-export const cloneSnapshotSoundSettings = (
-  settings: SnapshotSoundSettings | undefined,
-): SnapshotSoundSettings => ({
-  enabled: settings?.enabled ?? true,
-  volume: clamp01(settings?.volume, 1),
-  bindings: { ...(settings?.bindings ?? {}) },
-  cooldownMs: {
-    ...DEFAULT_SNAPSHOT_SOUND_COOLDOWNS,
-    ...(settings?.cooldownMs ?? {}),
-  },
 });
 
 export const sanitizeSoundSettings = (
@@ -413,39 +349,10 @@ export const sanitizeSoundSettings = (
       : {};
   const enabled = typeof record.enabled === 'boolean' ? record.enabled : baseDefaults.enabled;
   const masterVolume = clamp01(asNumber(record.masterVolume), baseDefaults.masterVolume);
-  const useFallbackBeep =
-    typeof record.useFallbackBeep === 'boolean'
-      ? record.useFallbackBeep
-      : baseDefaults.useFallbackBeep ?? false;
   const bindings = sanitizeSoundBindingMap(record.bindings, APP_SOUND_EVENTS);
   return {
     enabled,
     masterVolume,
-    useFallbackBeep,
     bindings,
   } satisfies SoundSettings;
-};
-
-export const sanitizeSnapshotSoundSettings = (
-  value: unknown,
-  defaults?: SnapshotSoundSettings,
-): SnapshotSoundSettings => {
-  const baseDefaults = defaults ?? createDefaultSnapshotSoundSettings();
-  const record =
-    typeof value === 'object' && value !== null
-      ? (value as Partial<SnapshotSoundSettings> & Record<string, unknown>)
-      : {};
-  const enabled = typeof record.enabled === 'boolean' ? record.enabled : baseDefaults.enabled;
-  const volume = clamp01(asNumber(record.volume), baseDefaults.volume);
-  const bindings = sanitizeSoundBindingMap(record.bindings, SNAPSHOT_SOUND_EVENTS);
-  const cooldownMs = sanitizeSnapshotCooldownMap(
-    record.cooldownMs,
-    baseDefaults.cooldownMs ?? DEFAULT_SNAPSHOT_SOUND_COOLDOWNS,
-  );
-  return {
-    enabled,
-    volume,
-    bindings,
-    cooldownMs,
-  } satisfies SnapshotSoundSettings;
 };

--- a/classquest/src/ui/show/WeeklyShowPlayer.tsx
+++ b/classquest/src/ui/show/WeeklyShowPlayer.tsx
@@ -3,7 +3,7 @@ import { useApp } from '~/app/AppContext';
 import WeeklyShowSlide from '~/ui/show/WeeklyShowSlide';
 import { computeDeltasFromSnapshot, computeWeeklyDeltas, type WeeklyDelta } from '~/core/show/weekly';
 import { listSnapshots, type WeeklySnapshot } from '~/services/weeklyStorage';
-import { preloadSounds } from '~/utils/sounds';
+import { playSound, preloadSounds } from '~/utils/sounds';
 
 function formatDateLabel(snapshot: WeeklySnapshot): string {
   const created = new Date(snapshot.createdAt);
@@ -43,6 +43,7 @@ export default function WeeklyShowPlayer() {
   const [useSnapshot, setUseSnapshot] = React.useState(true);
   const [snapshots, setSnapshots] = React.useState<WeeklySnapshot[]>(() => listSnapshots());
   const [snapshotId, setSnapshotId] = React.useState<string | undefined>(() => listSnapshots()[0]?.id);
+  const showcaseSignatureRef = React.useRef<string | null>(null);
 
   React.useEffect(() => {
     const handleStorage = () => {
@@ -112,6 +113,19 @@ export default function WeeklyShowPlayer() {
     }
     return result;
   }, [state, fromISO, order, onlyChanged, useSnapshot, snapshotId, snapshots]);
+
+  React.useEffect(() => {
+    if (!deltas.length) {
+      showcaseSignatureRef.current = null;
+      return;
+    }
+    const signature = deltas.map((delta) => delta.studentId).join('|');
+    if (showcaseSignatureRef.current === signature) {
+      return;
+    }
+    showcaseSignatureRef.current = signature;
+    void playSound('showcase_start');
+  }, [deltas]);
 
   React.useEffect(() => {
     setCurrentIndex(0);

--- a/classquest/src/ui/show/WeeklyShowSlide.tsx
+++ b/classquest/src/ui/show/WeeklyShowSlide.tsx
@@ -3,7 +3,7 @@ import { useApp } from '~/app/AppContext';
 import { AvatarView } from '~/ui/avatar/AvatarView';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import EvolutionSequence from '~/ui/show/EvolutionSequence';
-import { playSnapshotSound } from '~/utils/sounds';
+import { playSound } from '~/utils/sounds';
 import type { WeeklyDelta } from '~/core/show/weekly';
 
 const AVATAR_SIZE = 220;
@@ -60,18 +60,15 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
       return;
     }
     if (phase === 'xp' && xpGain > 0) {
-      void playSnapshotSound('snap_xp');
+      void playSound('xp_awarded');
     }
     if (phase === 'level') {
       if (levelGain > 0) {
-        void playSnapshotSound('snap_level');
-      }
-      if (evolved) {
-        void playSnapshotSound('snap_avatar');
+        void playSound('level_up');
       }
     }
     if (phase === 'badges' && hasNewBadges) {
-      void playSnapshotSound('snap_badge');
+      void playSound('badge_award');
     }
   }, [evolved, hasNewBadges, levelGain, phase, studentId, xpGain]);
 

--- a/classquest/src/utils/__tests__/sounds.test.ts
+++ b/classquest/src/utils/__tests__/sounds.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { playSound, setSoundSettings } from '~/utils/sounds';
+import { DEFAULT_SETTINGS } from '~/core/config';
+import { createDefaultAssetSettings, createDefaultSoundSettings } from '~/types/settings';
+
+const urlStore = new Map<string, string>();
+
+vi.mock('~/utils/blobStore', () => ({
+  blobStore: {
+    getObjectUrl: vi.fn((key: string) => Promise.resolve(urlStore.get(key) ?? null)),
+    put: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+  public volume = 1;
+  public readonly play = vi.fn(async () => undefined);
+  constructor(public readonly src: string) {
+    MockAudio.instances.push(this);
+  }
+}
+
+const originalAudio = globalThis.Audio;
+const originalPerformance = globalThis.performance;
+
+const buildSettings = () => {
+  const assets = createDefaultAssetSettings();
+  assets.library = {
+    xp: { key: 'key-xp', type: 'audio', name: 'XP', createdAt: 0 },
+    level: { key: 'key-level', type: 'audio', name: 'Level', createdAt: 0 },
+    badge: { key: 'key-badge', type: 'audio', name: 'Badge', createdAt: 0 },
+    showcase: { key: 'key-showcase', type: 'audio', name: 'Showcase', createdAt: 0 },
+  };
+  const sounds = createDefaultSoundSettings();
+  sounds.enabled = true;
+  sounds.masterVolume = 0.6;
+  sounds.bindings = {
+    xp_awarded: 'xp',
+    level_up: 'level',
+    badge_award: 'badge',
+    showcase_start: 'showcase',
+  };
+  return {
+    ...DEFAULT_SETTINGS,
+    assets,
+    sounds,
+  };
+};
+
+describe('playSound', () => {
+  beforeEach(() => {
+    urlStore.clear();
+    MockAudio.instances = [];
+    globalThis.Audio = MockAudio as unknown as typeof Audio;
+    const times: Record<string, number> = {};
+    globalThis.performance = {
+      now: vi.fn(() => {
+        times.default = (times.default ?? 0) + 250;
+        return times.default;
+      }),
+    } as Performance;
+    setSoundSettings(null);
+  });
+
+  afterEach(() => {
+    if (originalAudio) {
+      globalThis.Audio = originalAudio;
+    } else {
+      // @ts-expect-error allow cleanup in tests
+      delete (globalThis as typeof globalThis & { Audio?: typeof Audio }).Audio;
+    }
+    if (originalPerformance) {
+      globalThis.performance = originalPerformance;
+    } else {
+      // @ts-expect-error allow cleanup in tests
+      delete (globalThis as typeof globalThis & { performance?: Performance }).performance;
+    }
+  });
+
+  it('plays assigned audio for each supported event', async () => {
+    const settings = buildSettings();
+    urlStore.set('key-xp', 'https://cdn.test/xp.mp3');
+    urlStore.set('key-level', 'https://cdn.test/level.mp3');
+    urlStore.set('key-badge', 'https://cdn.test/badge.mp3');
+    urlStore.set('key-showcase', 'https://cdn.test/showcase.mp3');
+    setSoundSettings(settings);
+
+    await playSound('xp_awarded');
+    await playSound('level_up');
+    await playSound('badge_award');
+    await playSound('showcase_start');
+
+    expect(MockAudio.instances).toHaveLength(4);
+    expect(MockAudio.instances[0].src).toBe('https://cdn.test/xp.mp3');
+    expect(MockAudio.instances[0].volume).toBeCloseTo(0.6);
+    expect(MockAudio.instances[1].src).toBe('https://cdn.test/level.mp3');
+    expect(MockAudio.instances[2].src).toBe('https://cdn.test/badge.mp3');
+    expect(MockAudio.instances[3].src).toBe('https://cdn.test/showcase.mp3');
+  });
+
+  it('stays silent when no binding exists', async () => {
+    const settings = buildSettings();
+    settings.sounds.bindings = {};
+    setSoundSettings(settings);
+
+    await playSound('level_up');
+
+    expect(MockAudio.instances).toHaveLength(0);
+  });
+
+  it('respects cooldown for rapid xp events', async () => {
+    const settings = buildSettings();
+    urlStore.set('key-xp', 'https://cdn.test/xp.mp3');
+    setSoundSettings(settings);
+
+    let current = 1000;
+    globalThis.performance = {
+      now: vi.fn(() => current),
+    } as Performance;
+
+    await playSound('xp_awarded');
+    expect(MockAudio.instances).toHaveLength(1);
+
+    current += 100;
+    await playSound('xp_awarded');
+    expect(MockAudio.instances).toHaveLength(1);
+
+    current += 300;
+    await playSound('xp_awarded');
+    expect(MockAudio.instances).toHaveLength(2);
+  });
+});

--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -1,11 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { processAward } from '~/core/gameLogic';
 import type { AppState, Quest, Student } from '~/types/models';
-import {
-  createDefaultAssetSettings,
-  createDefaultSnapshotSoundSettings,
-  createDefaultSoundSettings,
-} from '~/types/settings';
+import { createDefaultAssetSettings, createDefaultSoundSettings } from '~/types/settings';
 
 const createStudent = (overrides: Partial<Student> = {}): Student => ({
   id: 'student-1',
@@ -34,7 +30,6 @@ const createState = (studentOverrides: Partial<Student> = {}): AppState => {
       allowNegativeXP: false,
       assets: createDefaultAssetSettings(),
       sounds: createDefaultSoundSettings(),
-      snapshotSounds: createDefaultSnapshotSoundSettings(),
     },
     version: 1,
     classProgress: { totalXP, stars: Math.floor(totalXP / 1000) },
@@ -107,7 +102,6 @@ describe('processAward', () => {
         allowNegativeXP: true,
         assets: createDefaultAssetSettings(),
         sounds: createDefaultSoundSettings(),
-        snapshotSounds: createDefaultSnapshotSoundSettings(),
       },
     } satisfies AppState;
 

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -2,11 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalStorageAdapter, STORAGE_KEY } from '~/services/storage/localStorage';
 import type { AppState } from '~/types/models';
 import { sanitizeState } from '~/core/schema/appState';
-import {
-  createDefaultAssetSettings,
-  createDefaultSnapshotSoundSettings,
-  createDefaultSoundSettings,
-} from '~/types/settings';
+import { createDefaultAssetSettings, createDefaultSoundSettings } from '~/types/settings';
 
 type GlobalWithStorage = typeof globalThis & { localStorage?: Storage };
 
@@ -50,7 +46,6 @@ const sampleState = (): AppState => ({
     allowNegativeXP: false,
     assets: createDefaultAssetSettings(),
     sounds: createDefaultSoundSettings(),
-    snapshotSounds: createDefaultSnapshotSoundSettings(),
   },
   version: 1,
   classProgress: { totalXP: 10, stars: 0 },


### PR DESCRIPTION
## Summary
- streamline the sound settings model to the four supported events and drop legacy snapshot bindings
- update the manage assets tab and showcase views to play the curated XP, level, badge, and showcase start sounds
- add unit tests that verify uploaded sounds play correctly, stay silent without a binding, and respect the cooldown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d56bbcc124832c9447f3af4a9cc3b8