### PR TITLE
feat: reorganize dashboard layout and navigation

### DIFF
--- a/classquest/src/App.css
+++ b/classquest/src/App.css
@@ -1,59 +1,225 @@
-.app-shell {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 24px 20px 48px;
+.layout-root {
+  display: flex;
+  min-height: 100vh;
+  color: var(--text);
 }
 
-.app-header {
+.layout-sidebar {
+  width: 248px;
+  padding: 28px 20px;
+  background: color-mix(in srgb, var(--card) 92%, rgba(7, 11, 22, 0.9));
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.sidebar-brand {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 16px;
 }
 
-.app-brand {
-  margin: 0;
-  font-size: 1.75rem;
+.sidebar-brand__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(16, 185, 129, 0.95));
   font-weight: 700;
-  letter-spacing: -0.01em;
+  font-size: 1.05rem;
 }
 
-.app-tabs {
+.sidebar-brand__meta {
+  display: grid;
+  gap: 2px;
+}
+
+.sidebar-brand__title {
+  font-size: 1.15rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.sidebar-brand__subtitle {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar-nav--secondary {
+  margin-top: auto;
+  padding-top: 20px;
+  border-top: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.sidebar-nav__item {
   display: flex;
-  gap: 8px;
-  margin-left: auto;
-  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  border: none;
+  border-radius: 14px;
+  background: transparent;
+  color: inherit;
+  font-weight: 600;
+  padding: 10px 14px;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.app-tab {
-  position: relative;
+.sidebar-nav__item:hover {
+  background: rgba(148, 163, 184, 0.12);
+  transform: translateY(-1px);
+}
+
+.sidebar-nav__item:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.sidebar-nav__item[aria-current='page'] {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.24), rgba(16, 185, 129, 0.24));
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.35);
+}
+
+.sidebar-nav__item--secondary {
+  font-weight: 500;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.sidebar-nav__icon {
+  width: 20px;
+  height: 20px;
+}
+
+.layout-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  background: color-mix(in srgb, var(--bg) 92%, rgba(2, 6, 23, 0.95));
+}
+
+.layout-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 32px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: color-mix(in srgb, var(--bg) 88%, rgba(15, 23, 42, 0.35));
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+}
+
+.topbar-class {
+  background: none;
+  border: none;
+  display: grid;
+  gap: 4px;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+}
+
+.topbar-class__name {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.topbar-class__meta {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.topbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.topbar-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
   padding: 10px 16px;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-color: color-mix(in srgb, var(--text) 12%, transparent);
-  background: var(--card);
-  background: color-mix(in srgb, var(--card) 82%, transparent);
-  color: var(--text);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(148, 163, 184, 0.08);
+  color: inherit;
   font-weight: 600;
-  font-size: 0.95rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease,
-    box-shadow 0.12s ease, color 0.12s ease;
+  transition: transform 0.12s ease, box-shadow 0.2s ease, background 0.2s ease;
 }
 
-.app-tab[aria-selected='true'] {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: var(--bg);
+.topbar-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 8px 24px rgba(10, 16, 28, 0.35);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.35);
 }
 
-.app-tab:focus-visible {
-  outline: 2px solid var(--ring);
+.topbar-button:focus-visible {
+  outline: 3px solid var(--ring);
   outline-offset: 2px;
+}
+
+.topbar-button__label {
+  font-size: 0.95rem;
+}
+
+.topbar-button__shortcut {
+  font-size: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 6px;
+  padding: 2px 6px;
+  background: rgba(15, 23, 42, 0.4);
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.icon-button {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  color: inherit;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.2s ease;
+}
+
+.icon-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.4);
+}
+
+.icon-button:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.layout-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.layout-content > * {
+  max-width: 1180px;
+  width: 100%;
+  margin: 0 auto;
 }
 
 .toast-region {
@@ -64,22 +230,62 @@
   z-index: 30;
 }
 
-@media (max-width: 720px) {
-  .app-shell {
-    padding: 16px 12px 32px;
+@media (max-width: 1024px) {
+  .layout-sidebar {
+    width: 220px;
+    padding: 24px 16px;
   }
 
-  .app-brand {
-    font-size: 1.4rem;
+  .layout-topbar {
+    padding: 20px 24px;
   }
 
-  .app-tabs {
+  .layout-content {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 820px) {
+  .layout-root {
+    flex-direction: column;
+  }
+
+  .layout-sidebar {
     width: 100%;
-    justify-content: flex-start;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 20px;
   }
 
-  .app-tab {
-    flex: 1 1 120px;
-    text-align: center;
+  .sidebar-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .sidebar-nav--secondary {
+    margin-top: 0;
+    border-top: none;
+    padding-top: 0;
+  }
+
+  .layout-main {
+    min-height: calc(100vh - 160px);
+  }
+}
+
+@media (max-width: 640px) {
+  .topbar-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .topbar-button {
+    padding: 8px 14px;
+  }
+
+  .layout-content {
+    padding: 20px;
   }
 }

--- a/classquest/src/types/navigation.ts
+++ b/classquest/src/types/navigation.ts
@@ -1,0 +1,3 @@
+export type AppTab = 'dashboard' | 'students' | 'rewards' | 'goals' | 'log' | 'manage' | 'info';
+
+export const KEYBOARD_TAB_ORDER: AppTab[] = ['dashboard', 'students', 'rewards', 'goals', 'log', 'manage'];

--- a/classquest/src/ui/screens/DashboardScreen.tsx
+++ b/classquest/src/ui/screens/DashboardScreen.tsx
@@ -1,0 +1,170 @@
+import { useMemo } from 'react';
+import { useApp } from '~/app/AppContext';
+import { selectClassProgress } from '~/core/selectors/classProgress';
+import { ClassProgressBar } from '~/ui/components/ClassProgressBar';
+import '~/ui/screens/dashboard.css';
+
+type DashboardScreenProps = {
+  onAddXp: () => void;
+  onOpenWeeklyShow: () => void;
+};
+
+const numberFormatter = new Intl.NumberFormat('de-DE');
+const timeFormatter = new Intl.DateTimeFormat('de-DE', {
+  dateStyle: 'short',
+  timeStyle: 'short',
+});
+
+function formatTimestamp(timestamp: number) {
+  try {
+    return timeFormatter.format(timestamp);
+  } catch (error) {
+    console.warn('Zeitstempel konnte nicht formatiert werden', error);
+    return new Date(timestamp).toLocaleString();
+  }
+}
+
+function SegmentedXpBar({ total, step }: { total: number; step: number }) {
+  const progress = step > 0 ? Math.min(1, (total % step) / step) : 0;
+  const percent = Math.round(progress * 100);
+  return (
+    <div className="dashboard-xpbar" aria-label="Fortschritt zum nächsten Stern">
+      <div
+        className="dashboard-xpbar__fill"
+        style={{ width: `${percent}%` }}
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+function StarRow({ stars }: { stars: number }) {
+  const totalVisible = Math.max(5, Math.min(8, stars + 1));
+  return (
+    <div className="dashboard-stars" aria-label={`Gesammelte Sterne: ${stars}`}>
+      {Array.from({ length: totalVisible }, (_, index) => {
+        const earned = index < stars;
+        return (
+          <span
+            key={index}
+            className={`dashboard-star${earned ? ' dashboard-star--earned' : ''}`}
+            aria-hidden
+          >
+            ★
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function DashboardScreen({ onAddXp, onOpenWeeklyShow }: DashboardScreenProps) {
+  const { state } = useApp();
+  const classProgress = selectClassProgress(state);
+  const aliasById = useMemo(
+    () => new Map(state.students.map((student) => [student.id, student.alias])),
+    [state.students],
+  );
+  const recentLogs = useMemo(() => state.logs.slice(0, 6), [state.logs]);
+  const topStudents = useMemo(() => {
+    const sorted = [...state.students];
+    sorted.sort((a, b) => b.xp - a.xp);
+    return sorted.slice(0, 6);
+  }, [state.students]);
+
+  const remaining = numberFormatter.format(Math.max(0, classProgress.remaining));
+  const step = numberFormatter.format(classProgress.step);
+  const segmentTotal = numberFormatter.format(classProgress.total % classProgress.step);
+
+  return (
+    <div className="dashboard">
+      <section className="dashboard-card dashboard-card--highlight" aria-label="Klassenstatus">
+        <div className="dashboard-card__header">
+          <div>
+            <p className="dashboard-card__eyebrow">Aktuelles Ziel</p>
+            <h1 className="dashboard-card__title">{state.settings.className || 'ClassQuest'}</h1>
+            <p className="dashboard-card__subtitle">
+              Noch {remaining} XP bis zum nächsten Stern · Schrittgröße {step} XP
+            </p>
+          </div>
+          <div className="dashboard-card__count" aria-live="polite">
+            <span className="dashboard-card__count-label">Sterne</span>
+            <span className="dashboard-card__count-value">{numberFormatter.format(classProgress.stars)}</span>
+          </div>
+        </div>
+        <div className="dashboard-card__actions">
+          <button type="button" className="dashboard-button" onClick={onAddXp}>
+            + XP vergeben
+          </button>
+          <button type="button" className="dashboard-button dashboard-button--ghost" onClick={onOpenWeeklyShow}>
+            Weekly Show starten
+          </button>
+        </div>
+      </section>
+
+      <div className="dashboard-grid">
+        <section className="dashboard-card" aria-label="Klassenfortschritt">
+          <header className="dashboard-section-head">
+            <div>
+              <h2>Fortschritt zum nächsten Stern</h2>
+              <p>Segment-XP: {segmentTotal} / {step}</p>
+            </div>
+            <button type="button" className="dashboard-link" onClick={onAddXp}>
+              XP hinzufügen
+            </button>
+          </header>
+          <SegmentedXpBar total={classProgress.total} step={classProgress.step} />
+          <StarRow stars={classProgress.stars} />
+          <ClassProgressBar />
+        </section>
+
+        <section className="dashboard-card" aria-label="Neueste Aktivitäten">
+          <header className="dashboard-section-head">
+            <h2>Letzte Aktivitäten</h2>
+          </header>
+          {recentLogs.length === 0 ? (
+            <p className="dashboard-empty">Noch keine Aktivitäten – vergebe XP, um loszulegen.</p>
+          ) : (
+            <ul className="dashboard-activity">
+              {recentLogs.map((log) => {
+                const alias = aliasById.get(log.studentId) ?? 'Unbekannt';
+                return (
+                  <li key={log.id} className="dashboard-activity__item">
+                    <div className="dashboard-activity__meta">
+                      <span className="dashboard-activity__time">{formatTimestamp(log.timestamp)}</span>
+                      <span className="dashboard-activity__xp">+{numberFormatter.format(log.xp)} XP</span>
+                    </div>
+                    <p className="dashboard-activity__title">{alias}</p>
+                    <p className="dashboard-activity__detail">{log.questName}</p>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </section>
+      </div>
+
+      <section className="dashboard-card" aria-label="Highlights der Schüler:innen">
+        <header className="dashboard-section-head">
+          <h2>Top Schüler:innen</h2>
+          <p>Highlights aus der Woche – keine Rangliste, nur Motivation.</p>
+        </header>
+        {topStudents.length === 0 ? (
+          <p className="dashboard-empty">Füge Schüler:innen hinzu, um Highlights zu sehen.</p>
+        ) : (
+          <ul className="dashboard-top">
+            {topStudents.map((student) => (
+              <li key={student.id} className="dashboard-top__item">
+                <div className="dashboard-top__alias">{student.alias}</div>
+                <div className="dashboard-top__meta">
+                  <span className="dashboard-top__xp">{numberFormatter.format(student.xp)} XP</span>
+                  <span className="dashboard-top__level">Level {student.level}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/classquest/src/ui/screens/dashboard.css
+++ b/classquest/src/ui/screens/dashboard.css
@@ -1,0 +1,278 @@
+.dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dashboard-card {
+  background: color-mix(in srgb, var(--card) 92%, transparent);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 24px;
+  box-shadow: 0 18px 48px rgba(15, 23, 42, 0.22);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.dashboard-card--highlight {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.28), rgba(16, 185, 129, 0.28));
+  border: 1px solid rgba(59, 130, 246, 0.35);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.35);
+}
+
+.dashboard-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+}
+
+.dashboard-card__eyebrow {
+  margin: 0 0 4px;
+  font-size: 0.875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.dashboard-card__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.dashboard-card__subtitle {
+  margin: 8px 0 0;
+  color: rgba(226, 232, 240, 0.82);
+  font-size: 0.95rem;
+}
+
+.dashboard-card__count {
+  min-width: 120px;
+  display: grid;
+  justify-items: end;
+  gap: 4px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.36);
+}
+
+.dashboard-card__count-label {
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.75;
+}
+
+.dashboard-card__count-value {
+  font-size: 2.4rem;
+  font-weight: 700;
+}
+
+.dashboard-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.dashboard-button {
+  border: none;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #0b1220;
+  font-weight: 600;
+  padding: 10px 20px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.4);
+}
+
+.dashboard-button:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.dashboard-button--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid rgba(226, 232, 240, 0.5);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.dashboard-section-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.dashboard-section-head h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.dashboard-section-head p {
+  margin: 4px 0 0;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.95rem;
+}
+
+.dashboard-link {
+  background: none;
+  border: none;
+  color: var(--accent-2);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dashboard-link:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.dashboard-xpbar {
+  position: relative;
+  height: 14px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.4);
+  overflow: hidden;
+}
+
+.dashboard-xpbar__fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(90deg, rgba(59, 130, 246, 1), rgba(56, 189, 248, 1));
+  border-radius: inherit;
+  transition: width 0.6s ease;
+}
+
+.dashboard-stars {
+  display: flex;
+  gap: 10px;
+  font-size: 2.2rem;
+}
+
+.dashboard-star {
+  color: rgba(148, 163, 184, 0.45);
+  transition: transform 0.25s ease, color 0.25s ease;
+}
+
+.dashboard-star--earned {
+  color: var(--accent);
+  transform: scale(1.05);
+}
+
+.dashboard-activity {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
+}
+
+.dashboard-activity__item {
+  padding: 14px 16px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  display: grid;
+  gap: 8px;
+}
+
+.dashboard-activity__meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.dashboard-activity__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1.05rem;
+}
+
+.dashboard-activity__detail {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.72);
+  font-size: 0.95rem;
+}
+
+.dashboard-empty {
+  margin: 8px 0 0;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.dashboard-top {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.dashboard-top__item {
+  background: rgba(15, 23, 42, 0.28);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 16px;
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.dashboard-top__alias {
+  font-weight: 600;
+}
+
+.dashboard-top__meta {
+  display: grid;
+  gap: 4px;
+  text-align: right;
+  font-size: 0.875rem;
+  color: rgba(226, 232, 240, 0.72);
+}
+
+.dashboard-top__xp {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent-2);
+}
+
+.dashboard-top__level {
+  opacity: 0.8;
+}
+
+@media (max-width: 960px) {
+  .dashboard-card__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .dashboard-card__count {
+    justify-items: start;
+  }
+}
+
+@media (max-width: 680px) {
+  .dashboard-card {
+    padding: 20px;
+  }
+
+  .dashboard {
+    gap: 20px;
+  }
+}

--- a/classquest/src/ui/shortcut/CommandPalette.tsx
+++ b/classquest/src/ui/shortcut/CommandPalette.tsx
@@ -11,8 +11,7 @@ import {
   EVENT_TOGGLE_GROUP_FILTER,
   EVENT_UNDO_PERFORMED,
 } from './events';
-
-type Tab = 'award' | 'leaderboard' | 'overview' | 'log' | 'manage' | 'info';
+import type { AppTab } from '~/types/navigation';
 
 type PaletteItem = {
   id: string;
@@ -25,40 +24,53 @@ type PaletteItem = {
 type CommandPaletteProps = {
   open: boolean;
   onClose: () => void;
-  setTab: (tab: Tab) => void;
+  setTab: (tab: AppTab) => void;
   onOpenSeasonReset: () => void;
 };
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function createPaletteItems(
   params: {
-    setTab: (tab: Tab) => void;
+    setTab: (tab: AppTab) => void;
     onOpenSeasonReset: () => void;
     dispatch: ReturnType<typeof useApp>['dispatch'];
     state: ReturnType<typeof useApp>['state'];
   },
 ): PaletteItem[] {
   const { state, dispatch, setTab, onOpenSeasonReset } = params;
-  const afterTab = (tab: Tab, fn: () => void) => {
+  const afterTab = (tab: AppTab, fn: () => void) => {
     setTab(tab);
     window.setTimeout(fn, 20);
   };
 
   const navItems: PaletteItem[] = [
-    { id: 'nav-award', label: 'Gehe zu: Vergeben', group: 'Navigation', keywords: 'award', run: () => setTab('award') },
     {
-      id: 'nav-leaderboard',
-      label: 'Gehe zu: Leaderboard',
+      id: 'nav-dashboard',
+      label: 'Gehe zu: Dashboard',
       group: 'Navigation',
-      keywords: 'ranking',
-      run: () => setTab('leaderboard'),
+      keywords: 'dashboard start home',
+      run: () => setTab('dashboard'),
     },
     {
-      id: 'nav-overview',
-      label: 'Gehe zu: Überblick',
+      id: 'nav-students',
+      label: 'Gehe zu: Schüler:innen',
       group: 'Navigation',
-      keywords: 'overview klasse klassenübersicht',
-      run: () => setTab('overview'),
+      keywords: 'schüler studenten übersicht',
+      run: () => setTab('students'),
+    },
+    {
+      id: 'nav-rewards',
+      label: 'Gehe zu: Belohnungen',
+      group: 'Navigation',
+      keywords: 'award belohnung xp',
+      run: () => setTab('rewards'),
+    },
+    {
+      id: 'nav-goals',
+      label: 'Gehe zu: Klassenziele',
+      group: 'Navigation',
+      keywords: 'ziele klasse fortschritt leaderboard',
+      run: () => setTab('goals'),
     },
     { id: 'nav-log', label: 'Gehe zu: Protokoll', group: 'Navigation', keywords: 'log', run: () => setTab('log') },
     { id: 'nav-manage', label: 'Gehe zu: Verwalten', group: 'Navigation', keywords: 'manage', run: () => setTab('manage') },
@@ -107,7 +119,7 @@ export function createPaletteItems(
       label: 'Alle auswählen (Vergeben)',
       group: 'Aktionen',
       run: () => {
-        afterTab('award', () => window.dispatchEvent(new Event(EVENT_SELECT_ALL)));
+        afterTab('rewards', () => window.dispatchEvent(new Event(EVENT_SELECT_ALL)));
       },
     },
   ];
@@ -118,7 +130,7 @@ export function createPaletteItems(
     group: 'Schüler',
     keywords: student.alias,
     run: () => {
-      afterTab('award', () => {
+      afterTab('rewards', () => {
         window.dispatchEvent(new CustomEvent(EVENT_FOCUS_STUDENT, { detail: student.id }));
       });
     },
@@ -132,7 +144,7 @@ export function createPaletteItems(
       group: 'Quests',
       keywords: quest.name,
       run: () => {
-        afterTab('award', () => {
+        afterTab('rewards', () => {
           window.dispatchEvent(new CustomEvent(EVENT_SET_ACTIVE_QUEST, { detail: quest.id }));
         });
       },
@@ -142,13 +154,13 @@ export function createPaletteItems(
     id: `group-${team.id}`,
     label: `Gruppe filtern: ${team.name}`,
     group: 'Gruppen',
-    keywords: team.name,
-    run: () => {
-      afterTab('award', () => {
-        window.dispatchEvent(new CustomEvent(EVENT_TOGGLE_GROUP_FILTER, { detail: team.id }));
-      });
-    },
-  }));
+      keywords: team.name,
+      run: () => {
+        afterTab('rewards', () => {
+          window.dispatchEvent(new CustomEvent(EVENT_TOGGLE_GROUP_FILTER, { detail: team.id }));
+        });
+      },
+    }));
 
   return [...navItems, ...actions, ...studentItems, ...questItems, ...groupItems];
 }

--- a/classquest/src/ui/student/navigate.ts
+++ b/classquest/src/ui/student/navigate.ts
@@ -1,9 +1,10 @@
 import { EVENT_FOCUS_STUDENT, EVENT_NAVIGATE_TAB } from '~/ui/shortcut/events';
+import type { AppTab } from '~/types/navigation';
 
-type NavigateDetail = { tab: 'award'; studentId?: string };
+type NavigateDetail = { tab: AppTab; studentId?: string };
 
 export function navigateToAwardScreen(studentId?: string | null) {
-  const detail: NavigateDetail = { tab: 'award' };
+  const detail: NavigateDetail = { tab: 'rewards' };
   if (studentId) {
     detail.studentId = studentId;
   }


### PR DESCRIPTION
## Summary
- replace the legacy tab header with a sidebar app shell that adds topbar quick actions, theme cycling, and weekly show launch
- introduce a dashboard screen highlighting class progress, recent activity, and student highlights with new surface styling
- update command palette and navigation helpers to use the new tab identifiers and keyboard mapping

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6bb1baca0832c870ac535e6f9c541