### PR TITLE
Add modular sound manager with settings controls

### DIFF
--- a/classquest/package-lock.json
+++ b/classquest/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.12",
+        "howler": "^2.2.4",
         "lottie-web": "^5.13.0",
         "lucide-react": "^0.544.0",
         "react": "^18.2.0",
@@ -2935,6 +2936,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/howler": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/howler/-/howler-2.2.4.tgz",
+      "integrity": "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w==",
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",

--- a/classquest/package.json
+++ b/classquest/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.12",
+    "howler": "^2.2.4",
     "lottie-web": "^5.13.0",
     "lucide-react": "^0.544.0",
     "react": "^18.2.0",

--- a/classquest/public/sfx/README.md
+++ b/classquest/public/sfx/README.md
@@ -1,0 +1,3 @@
+# Sound Assets Placeholder
+
+Place your audio files for the sound manager in this directory. Ensure that the file names match the defaults referenced in `src/audio/sounds.ts` or adjust the configuration as needed.

--- a/classquest/src/audio/SoundManager.ts
+++ b/classquest/src/audio/SoundManager.ts
@@ -1,0 +1,187 @@
+import { Howl, Howler } from 'howler';
+import { SOUND_DEFINITIONS, SOUND_KEYS, SOUND_COOLDOWNS_MS } from './sounds';
+import type { PlayOptions, SoundKey } from './types';
+
+const SAFE_MIN_VOLUME = 0;
+const SAFE_MAX_VOLUME = 1;
+
+class SoundManager {
+  private howls = new Map<SoundKey, Howl>();
+  private lastPlay = new Map<SoundKey, number>();
+  private cooldowns = new Map<SoundKey, number>();
+  private initialized = false;
+  private unlocked = false;
+  private muted = false;
+  private masterVolume = 1;
+
+  init(): void {
+    SOUND_KEYS.forEach((key) => {
+      const definition = SOUND_DEFINITIONS[key];
+      if (!definition) {
+        return;
+      }
+
+      const cooldown = definition.cooldown ?? SOUND_COOLDOWNS_MS[key] ?? 0;
+      this.cooldowns.set(key, cooldown);
+
+      if (this.howls.has(key)) {
+        return;
+      }
+
+      try {
+        const howl = new Howl({
+          src: definition.sources,
+          html5: false,
+          preload: true,
+          ...(definition.options ?? {}),
+        });
+
+        howl.on('loaderror', (_id, error) => {
+          console.warn(`[SoundManager] Failed to load sound "${key}"`, error);
+        });
+
+        this.howls.set(key, howl);
+      } catch (error) {
+        console.warn(`[SoundManager] Error creating sound "${key}"`, error);
+      }
+    });
+
+    this.initialized = true;
+    this.applyVolume();
+    this.applyMute();
+  }
+
+  unlock(): void {
+    if (this.unlocked) {
+      return;
+    }
+
+    const ctx = Howler.ctx as (AudioContext | undefined);
+
+    if (ctx && ctx.state === 'suspended') {
+      ctx.resume().catch((error) => {
+        console.warn('[SoundManager] Failed to resume audio context', error);
+      });
+    }
+
+    if (ctx) {
+      try {
+        const buffer = ctx.createBuffer(1, 1, 22050);
+        const source = ctx.createBufferSource();
+        source.buffer = buffer;
+        source.connect(ctx.destination);
+        source.start(0);
+        source.stop(0);
+        source.disconnect();
+      } catch (error) {
+        console.warn('[SoundManager] Unlock shim failed', error);
+      }
+    }
+
+    this.unlocked = true;
+  }
+
+  play(key: SoundKey, opts?: PlayOptions): void {
+    if (!this.initialized) {
+      this.init();
+    }
+
+    if (this.muted) {
+      return;
+    }
+
+    const howl = this.howls.get(key);
+    if (!howl) {
+      return;
+    }
+
+    const now = this.getTimestamp();
+    const cooldown = this.cooldowns.get(key) ?? 0;
+    const last = this.lastPlay.get(key);
+    if (cooldown > 0 && last !== undefined && now - last < cooldown) {
+      return;
+    }
+
+    try {
+      const playId = howl.play();
+      if (typeof playId === 'number') {
+        if (opts?.volume !== undefined) {
+          howl.volume(this.clampVolume(opts.volume), playId);
+        }
+        if (opts?.rate !== undefined) {
+          howl.rate(opts.rate, playId);
+        }
+      }
+      this.lastPlay.set(key, now);
+    } catch (error) {
+      console.warn(`[SoundManager] Failed to play sound "${key}"`, error);
+    }
+  }
+
+  stop(key?: SoundKey): void {
+    if (key) {
+      this.howls.get(key)?.stop();
+      return;
+    }
+
+    this.howls.forEach((howl) => {
+      howl.stop();
+    });
+  }
+
+  setVolume(volume: number): void {
+    this.masterVolume = this.clampVolume(volume);
+    this.applyVolume();
+  }
+
+  getVolume(): number {
+    return this.masterVolume;
+  }
+
+  setMuted(muted: boolean): void {
+    this.muted = muted;
+    this.applyMute();
+  }
+
+  isMuted(): boolean {
+    return this.muted;
+  }
+
+  setCooldown(key: SoundKey, ms: number): void {
+    this.cooldowns.set(key, Math.max(0, ms));
+  }
+
+  private applyVolume(): void {
+    try {
+      Howler.volume(this.masterVolume);
+    } catch (error) {
+      console.warn('[SoundManager] Failed to set master volume', error);
+    }
+  }
+
+  private applyMute(): void {
+    try {
+      Howler.mute(this.muted);
+    } catch (error) {
+      console.warn('[SoundManager] Failed to set mute state', error);
+    }
+  }
+
+  private clampVolume(volume: number): number {
+    if (Number.isNaN(volume)) {
+      return this.masterVolume;
+    }
+
+    return Math.min(SAFE_MAX_VOLUME, Math.max(SAFE_MIN_VOLUME, volume));
+  }
+
+  private getTimestamp(): number {
+    if (typeof performance !== 'undefined') {
+      return performance.now();
+    }
+
+    return Date.now();
+  }
+}
+
+export const soundManager = new SoundManager();

--- a/classquest/src/audio/SoundSettingsPanel.tsx
+++ b/classquest/src/audio/SoundSettingsPanel.tsx
@@ -1,0 +1,123 @@
+import type { ChangeEvent } from 'react';
+import { useCallback } from 'react';
+import { soundManager } from './SoundManager';
+import { SOUND_KEYS } from './sounds';
+import { useSoundSettings } from './useSoundSettings';
+import type { SoundKey } from './types';
+
+const SOUND_LABELS: Record<SoundKey, string> = {
+  'xp-grant': 'XP vergeben',
+  'level-up': 'Level-Up',
+  'badge-award': 'Badge vergeben',
+  'slideshow-avatar': 'Slideshow Avatar',
+  'slideshow-badge-flyin': 'Slideshow Badge-Fly-in',
+};
+
+export function SoundSettingsPanel(): JSX.Element {
+  const { settings, setEnabled, setVolume } = useSoundSettings();
+
+  const handleToggle = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setEnabled(event.target.checked);
+    },
+    [setEnabled],
+  );
+
+  const handleVolumeChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const next = parseFloat(event.target.value);
+      setVolume(next);
+    },
+    [setVolume],
+  );
+
+  const handleTestSound = useCallback((key: SoundKey) => {
+    soundManager.unlock();
+    soundManager.play(key);
+  }, []);
+
+  const volumePercent = Math.round(settings.volume * 100);
+
+  return (
+    <section className="w-full max-w-xl space-y-6 rounded-2xl border border-slate-700 bg-slate-950 p-6 text-slate-100 shadow-lg">
+      <header className="space-y-1">
+        <h2 className="text-xl font-semibold">Sound-Einstellungen</h2>
+        <p className="text-sm text-slate-300">
+          Passe Lautstärke und Soundeffekte für Auszeichnungen, Level-Ups und die Slideshow an.
+        </p>
+      </header>
+
+      <div className="flex items-center justify-between gap-4 rounded-xl bg-slate-900 p-4 shadow-inner">
+        <div className="space-y-1">
+          <p className="text-base font-medium">Sound aktivieren</p>
+          <p className="text-xs text-slate-300">Schaltet alle Soundeffekte global ein oder aus.</p>
+        </div>
+        <label className="relative inline-flex h-8 w-14 cursor-pointer items-center">
+          <span className="sr-only">Sound aktivieren</span>
+          <input
+            aria-label="Sound aktivieren"
+            checked={settings.enabled}
+            className="peer sr-only"
+            onChange={handleToggle}
+            type="checkbox"
+          />
+          <span className="absolute inset-0 rounded-full bg-slate-700 transition peer-checked:bg-emerald-500 peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-emerald-400" />
+          <span className="absolute left-1 top-1 h-6 w-6 rounded-full bg-white transition peer-checked:translate-x-6 peer-checked:bg-slate-950" />
+        </label>
+      </div>
+
+      <div className="space-y-3 rounded-xl bg-slate-900 p-4 shadow-inner">
+        <div className="flex items-center justify-between text-sm text-slate-300">
+          <span className="font-medium text-slate-100">Lautstärke</span>
+          <span>{volumePercent}%</span>
+        </div>
+        <input
+          aria-label="Lautstärke"
+          className="h-2 w-full cursor-pointer appearance-none rounded-full bg-slate-700 accent-emerald-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-400"
+          max={1}
+          min={0}
+          onChange={handleVolumeChange}
+          step={0.01}
+          type="range"
+          value={settings.volume}
+        />
+      </div>
+
+      <div className="space-y-2 rounded-xl bg-slate-900 p-4 shadow-inner">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-200">Test-Sounds</h3>
+        <p className="text-xs text-slate-400">
+          Hinweis: Falls kein Ton hörbar ist, klicke einmal auf „Audio entsperren“, um die Wiedergabe zu ermöglichen.
+        </p>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+          {SOUND_KEYS.map((key) => (
+            <button
+              key={key}
+              className="rounded-lg border border-emerald-500 bg-emerald-400 px-4 py-2 text-left text-sm font-semibold text-emerald-950 transition hover:border-emerald-300 hover:bg-emerald-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-200"
+              onClick={() => handleTestSound(key)}
+              type="button"
+            >
+              {SOUND_LABELS[key]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-slate-700 bg-slate-900 p-4 text-sm text-slate-200">
+        <p className="mb-3 font-medium">Audio entsperren</p>
+        <p className="text-xs text-slate-400">
+          Browser blockieren Audio, bis eine Interaktion erfolgt. Klicke hier nach der ersten Nutzeraktion, um den Soundmanager
+          zu entsperren.
+        </p>
+        <button
+          className="mt-3 inline-flex items-center justify-center rounded-lg border border-slate-500 bg-slate-800 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-300 hover:bg-slate-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+          onClick={() => soundManager.unlock()}
+          type="button"
+        >
+          Audio entsperren
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default SoundSettingsPanel;

--- a/classquest/src/audio/__tests__/SoundManager.test.ts
+++ b/classquest/src/audio/__tests__/SoundManager.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const playMock = vi.fn(() => 1);
+  const stopMock = vi.fn();
+  const volumeMock = vi.fn();
+  const rateMock = vi.fn();
+  const onMock = vi.fn();
+  const howlerVolumeMock = vi.fn();
+  const howlerMuteMock = vi.fn();
+  const resumeMock = vi.fn().mockResolvedValue(undefined);
+
+  return {
+    playMock,
+    stopMock,
+    volumeMock,
+    rateMock,
+    onMock,
+    howlerVolumeMock,
+    howlerMuteMock,
+    resumeMock,
+  };
+});
+
+vi.mock('howler', () => {
+  class MockHowl {
+    options: unknown;
+
+    constructor(options: unknown) {
+      this.options = options;
+    }
+
+    play = mocks.playMock;
+    stop = mocks.stopMock;
+    volume = mocks.volumeMock;
+    rate = mocks.rateMock;
+    on = mocks.onMock;
+  }
+
+  const Howler = {
+    volume: mocks.howlerVolumeMock,
+    mute: mocks.howlerMuteMock,
+    ctx: { state: 'running' as const, resume: mocks.resumeMock },
+  };
+
+  return { Howl: MockHowl, Howler };
+});
+
+import { soundManager } from '../SoundManager';
+
+const resetInternals = () => {
+  const internals = soundManager as unknown as {
+    lastPlay: Map<string, number>;
+    cooldowns: Map<string, number>;
+    howls: Map<string, unknown>;
+    initialized: boolean;
+  };
+  internals.lastPlay.clear();
+  internals.cooldowns.clear();
+  internals.howls.clear();
+  internals.initialized = false;
+};
+
+describe('SoundManager', () => {
+  beforeEach(() => {
+    mocks.playMock.mockClear();
+    mocks.stopMock.mockClear();
+    mocks.volumeMock.mockClear();
+    mocks.rateMock.mockClear();
+    mocks.onMock.mockClear();
+    mocks.howlerVolumeMock.mockClear();
+    mocks.howlerMuteMock.mockClear();
+    resetInternals();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('respects cooldown for repeated plays', () => {
+    let currentTime = 0;
+    const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => currentTime);
+
+    soundManager.init();
+    expect(soundManager.isMuted()).toBe(false);
+
+    const internals = soundManager as unknown as { howls: Map<string, unknown> };
+    expect(internals.howls.has('xp-grant')).toBe(true);
+
+    soundManager.setCooldown('xp-grant', 400);
+
+    soundManager.play('xp-grant');
+    expect(mocks.playMock).toHaveBeenCalledTimes(1);
+
+    currentTime += 200;
+    soundManager.play('xp-grant');
+    expect(mocks.playMock).toHaveBeenCalledTimes(1);
+
+    currentTime += 400;
+    soundManager.play('xp-grant');
+    expect(mocks.playMock).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
+  it('sets master volume and mute state', () => {
+    soundManager.init();
+
+    soundManager.setVolume(0.5);
+    expect(mocks.howlerVolumeMock).toHaveBeenLastCalledWith(0.5);
+
+    soundManager.setMuted(true);
+    expect(mocks.howlerMuteMock).toHaveBeenLastCalledWith(true);
+
+    soundManager.setMuted(false);
+    expect(mocks.howlerMuteMock).toHaveBeenLastCalledWith(false);
+
+    soundManager.setVolume(2);
+    expect(mocks.howlerVolumeMock).toHaveBeenLastCalledWith(1);
+  });
+});

--- a/classquest/src/audio/sounds.ts
+++ b/classquest/src/audio/sounds.ts
@@ -1,0 +1,50 @@
+import type { HowlOptions } from 'howler';
+import type { SoundKey } from './types';
+
+export type SoundDefinition = {
+  sources: string[];
+  options?: Omit<HowlOptions, 'src'>;
+  cooldown?: number;
+};
+
+const base = '/sfx';
+
+export const SOUND_DEFINITIONS: Record<SoundKey, SoundDefinition> = {
+  'xp-grant': {
+    sources: [`${base}/xp_grant.mp3`, `${base}/xp_grant.ogg`],
+    cooldown: 400,
+    options: {
+      preload: true,
+    },
+  },
+  'level-up': {
+    sources: [`${base}/level_up.mp3`, `${base}/level_up.ogg`],
+    options: {
+      preload: true,
+    },
+  },
+  'badge-award': {
+    sources: [`${base}/badge_award.mp3`, `${base}/badge_award.ogg`],
+    options: {
+      preload: true,
+    },
+  },
+  'slideshow-avatar': {
+    sources: [`${base}/slide_avatar.mp3`, `${base}/slide_avatar.ogg`],
+    options: {
+      preload: true,
+    },
+  },
+  'slideshow-badge-flyin': {
+    sources: [`${base}/slide_badge_flyin.mp3`, `${base}/slide_badge_flyin.ogg`],
+    options: {
+      preload: true,
+    },
+  },
+};
+
+export const SOUND_KEYS = Object.keys(SOUND_DEFINITIONS) as SoundKey[];
+
+export const SOUND_COOLDOWNS_MS: Partial<Record<SoundKey, number>> = Object.fromEntries(
+  SOUND_KEYS.map((key) => [key, SOUND_DEFINITIONS[key].cooldown ?? 0]),
+) as Partial<Record<SoundKey, number>>;

--- a/classquest/src/audio/types.ts
+++ b/classquest/src/audio/types.ts
@@ -1,0 +1,16 @@
+export type SoundKey =
+  | 'xp-grant'
+  | 'level-up'
+  | 'badge-award'
+  | 'slideshow-avatar'
+  | 'slideshow-badge-flyin';
+
+export type PlayOptions = {
+  volume?: number;
+  rate?: number;
+};
+
+export type SoundSettings = {
+  enabled: boolean;
+  volume: number;
+};

--- a/classquest/src/audio/useSoundSettings.ts
+++ b/classquest/src/audio/useSoundSettings.ts
@@ -1,0 +1,131 @@
+import {
+  PropsWithChildren,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { soundManager } from './SoundManager';
+import type { SoundSettings } from './types';
+import { eventBus } from '@/lib/EventBus';
+
+const STORAGE_KEY = 'classquest:sound-settings';
+const DEFAULT_SETTINGS: SoundSettings = {
+  enabled: true,
+  volume: 0.8,
+};
+
+const clampVolume = (value: number): number => {
+  if (Number.isNaN(value)) {
+    return DEFAULT_SETTINGS.volume;
+  }
+
+  return Math.min(1, Math.max(0, value));
+};
+
+type SoundSettingsContextValue = {
+  settings: SoundSettings;
+  setEnabled: (enabled: boolean) => void;
+  setVolume: (volume: number) => void;
+};
+
+const SoundSettingsContext = createContext<SoundSettingsContextValue | null>(null);
+
+const loadSettings = (): SoundSettings => {
+  if (typeof window === 'undefined') {
+    return DEFAULT_SETTINGS;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return DEFAULT_SETTINGS;
+    }
+
+    const parsed = JSON.parse(raw) as Partial<SoundSettings>;
+    return {
+      enabled: parsed.enabled ?? DEFAULT_SETTINGS.enabled,
+      volume: clampVolume(parsed.volume ?? DEFAULT_SETTINGS.volume),
+    };
+  } catch (error) {
+    console.warn('[SoundSettings] Failed to load settings, using defaults', error);
+    return DEFAULT_SETTINGS;
+  }
+};
+
+const persistSettings = (settings: SoundSettings): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+  } catch (error) {
+    console.warn('[SoundSettings] Failed to persist settings', error);
+  }
+};
+
+export function SoundSettingsProvider({ children }: PropsWithChildren): JSX.Element {
+  const [settings, setSettings] = useState<SoundSettings>(() => loadSettings());
+
+  useEffect(() => {
+    soundManager.init();
+  }, []);
+
+  useEffect(() => {
+    persistSettings(settings);
+  }, [settings]);
+
+  useEffect(() => {
+    soundManager.setMuted(!settings.enabled);
+    if (!settings.enabled) {
+      soundManager.stop();
+    }
+  }, [settings.enabled]);
+
+  useEffect(() => {
+    soundManager.setVolume(settings.volume);
+  }, [settings.volume]);
+
+  useEffect(() => {
+    const offXp = eventBus.on('xp:granted', () => soundManager.play('xp-grant'));
+    const offLevel = eventBus.on('level:up', () => soundManager.play('level-up'));
+    const offBadge = eventBus.on('badge:awarded', () => soundManager.play('badge-award'));
+
+    return () => {
+      offXp();
+      offLevel();
+      offBadge();
+    };
+  }, []);
+
+  const setEnabled = useCallback((enabled: boolean) => {
+    setSettings((prev) => ({ ...prev, enabled }));
+  }, []);
+
+  const setVolume = useCallback((volume: number) => {
+    setSettings((prev) => ({ ...prev, volume: clampVolume(volume) }));
+  }, []);
+
+  const value = useMemo<SoundSettingsContextValue>(
+    () => ({
+      settings,
+      setEnabled,
+      setVolume,
+    }),
+    [setEnabled, setVolume, settings],
+  );
+
+  return <SoundSettingsContext.Provider value={value}>{children}</SoundSettingsContext.Provider>;
+}
+
+export function useSoundSettings(): SoundSettingsContextValue {
+  const context = useContext(SoundSettingsContext);
+  if (!context) {
+    throw new Error('useSoundSettings must be used within a SoundSettingsProvider');
+  }
+
+  return context;
+}

--- a/classquest/src/lib/EventBus.ts
+++ b/classquest/src/lib/EventBus.ts
@@ -1,0 +1,49 @@
+export type AppEvent =
+  | { type: 'xp:granted'; amount: number; newSegmentXP: number }
+  | { type: 'level:up'; newLevel: number }
+  | { type: 'badge:awarded'; badgeId: string; studentId?: string }
+  | { type: 'slideshow:avatar:present'; studentId: string }
+  | { type: 'slideshow:badge:flyin'; badgeId: string };
+
+type AnyHandler = (event: AppEvent) => void;
+
+const registry = new Map<AppEvent['type'], Set<AnyHandler>>();
+
+export const eventBus = {
+  on<T extends AppEvent['type']>(type: T, handler: (event: Extract<AppEvent, { type: T }>) => void): () => void {
+    const set = registry.get(type) ?? new Set<AnyHandler>();
+    if (!registry.has(type)) {
+      registry.set(type, set);
+    }
+
+    const wrapped: AnyHandler = (event) => {
+      handler(event as Extract<AppEvent, { type: T }>);
+    };
+
+    set.add(wrapped);
+
+    return () => {
+      set.delete(wrapped);
+      if (set.size === 0) {
+        registry.delete(type);
+      }
+    };
+  },
+  emit(event: AppEvent): void {
+    const handlers = registry.get(event.type);
+    if (!handlers || handlers.size === 0) {
+      return;
+    }
+
+    handlers.forEach((handler) => {
+      try {
+        handler(event);
+      } catch (error) {
+        console.warn(`[EventBus] Error while handling ${event.type}`, error);
+      }
+    });
+  },
+  clear(): void {
+    registry.clear();
+  },
+};

--- a/classquest/src/main.tsx
+++ b/classquest/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { SoundSettingsProvider } from './audio/useSoundSettings';
 import { AppProvider } from './app/AppContext';
 import { FeedbackProvider } from './ui/feedback/FeedbackProvider';
 import { KeyScopeProvider } from './ui/shortcut/KeyScope';
@@ -16,23 +17,27 @@ const isShowRoute = typeof window !== 'undefined' && window.location.pathname.st
 
 const appTree = (
   <React.StrictMode>
-    <AppProvider>
-      <FeedbackProvider>
-        <KeyScopeProvider>
-          <App />
-        </KeyScopeProvider>
-      </FeedbackProvider>
-    </AppProvider>
+    <SoundSettingsProvider>
+      <AppProvider>
+        <FeedbackProvider>
+          <KeyScopeProvider>
+            <App />
+          </KeyScopeProvider>
+        </FeedbackProvider>
+      </AppProvider>
+    </SoundSettingsProvider>
   </React.StrictMode>
 );
 
 const showTree = (
   <React.StrictMode>
-    <AppProvider>
-      <FeedbackProvider>
-        <WeeklyShowPlayer />
-      </FeedbackProvider>
-    </AppProvider>
+    <SoundSettingsProvider>
+      <AppProvider>
+        <FeedbackProvider>
+          <WeeklyShowPlayer />
+        </FeedbackProvider>
+      </AppProvider>
+    </SoundSettingsProvider>
   </React.StrictMode>
 );
 

--- a/classquest/src/slideshow/hooks/useSlideshowSounds.ts
+++ b/classquest/src/slideshow/hooks/useSlideshowSounds.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react';
+import { soundManager } from '@/audio/SoundManager';
+import { eventBus } from '@/lib/EventBus';
+
+const BADGE_FLYIN_DELAY_MS = 150;
+
+export function useSlideshowSounds(): void {
+  const badgeTimeoutRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    soundManager.init();
+    soundManager.unlock();
+
+    const handleBadgeFlyIn = () => {
+      if (badgeTimeoutRef.current) {
+        window.clearTimeout(badgeTimeoutRef.current);
+      }
+
+      badgeTimeoutRef.current = window.setTimeout(() => {
+        soundManager.play('slideshow-badge-flyin');
+        badgeTimeoutRef.current = null;
+      }, BADGE_FLYIN_DELAY_MS);
+    };
+
+    const offBadgeFlyIn = eventBus.on('slideshow:badge:flyin', handleBadgeFlyIn);
+    const offAvatarPresent = eventBus.on('slideshow:avatar:present', () => {
+      soundManager.play('slideshow-avatar');
+    });
+
+    return () => {
+      if (badgeTimeoutRef.current) {
+        window.clearTimeout(badgeTimeoutRef.current);
+        badgeTimeoutRef.current = null;
+      }
+
+      offBadgeFlyIn();
+      offAvatarPresent();
+    };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- add a howler-based SoundManager with cooldown handling, unlock gating, and global event bus integration
- provide persisted sound settings context plus a high-contrast control panel with test triggers and unlock guidance
- wire slideshow-specific sound playback and add unit coverage for cooldown and master controls

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6c0e03238832cb41a3a4059c106ae