### PR TITLE
Refine class XP milestone logic and UI

### DIFF
--- a/classquest/src/__tests__/badges.autorules.test.ts
+++ b/classquest/src/__tests__/badges.autorules.test.ts
@@ -92,7 +92,7 @@ const baseState: Mutable<AppState> = {
     classStarsName: 'Stern',
   },
   version: 1,
-  classProgress: { totalXP: 0, stars: 0 },
+  classProgress: { totalXP: 0, stars: 0, step: 1000, stepXP: 0, remainingXP: 1000 },
   badgeDefs: [],
   categories: [
     { id: 'cat-homework', name: 'homework', color: null },

--- a/classquest/src/__tests__/classProgress.test.ts
+++ b/classquest/src/__tests__/classProgress.test.ts
@@ -12,10 +12,14 @@ describe('class progress tracking', () => {
 
     expect(result.classProgress.totalXP).toBe(1200);
     expect(result.classProgress.stars).toBe(1);
+    expect(result.classProgress.step).toBe(state.settings.classMilestoneStep);
+    expect(result.classProgress.stepXP).toBe(200);
+    expect(result.classProgress.remainingXP).toBe(800);
 
     const summary = selectClassProgress(result);
     expect(summary.remaining).toBe(800);
-    expect(summary.nextTarget).toBe(2000);
+    expect(summary.step).toBe(result.settings.classMilestoneStep);
+    expect(summary.stepXP).toBe(200);
   });
 
   it('clamps total XP at zero when penalties would go negative', () => {
@@ -29,6 +33,8 @@ describe('class progress tracking', () => {
 
     expect(result.classProgress.totalXP).toBe(0);
     expect(result.classProgress.stars).toBe(0);
+    expect(result.classProgress.stepXP).toBe(0);
+    expect(result.classProgress.remainingXP).toBe(result.classProgress.step);
   });
 
   it('selectClassProgress respects custom milestone steps', () => {
@@ -37,15 +43,14 @@ describe('class progress tracking', () => {
     state = {
       ...state,
       settings: { ...state.settings, classMilestoneStep: 200 },
-      classProgress: { totalXP: 450, stars: 2 },
+      classProgress: { totalXP: 450, stars: 2, step: 200, stepXP: 50, remainingXP: 150 },
     };
 
     const summary = selectClassProgress(state);
 
     expect(summary.step).toBe(200);
     expect(summary.stars).toBe(2);
-    expect(summary.nextTarget).toBe(600);
+    expect(summary.stepXP).toBe(50);
     expect(summary.remaining).toBe(150);
-    expect(Math.round(summary.ratio * 100)).toBe(75);
   });
 });

--- a/classquest/src/core/classProgress.ts
+++ b/classquest/src/core/classProgress.ts
@@ -1,0 +1,31 @@
+import { DEFAULT_SETTINGS } from './config';
+import type { ClassProgress, Settings, Student } from '~/types/models';
+
+export const normalizeClassMilestoneStep = (step?: number | null): number => {
+  const numericCandidate = Number(step);
+  const numeric = Number.isFinite(numericCandidate)
+    ? Math.floor(numericCandidate)
+    : DEFAULT_SETTINGS.classMilestoneStep;
+  return Math.max(1, numeric || DEFAULT_SETTINGS.classMilestoneStep);
+};
+
+export const calculateClassProgress = (
+  totalXPInput: number,
+  stepInput?: number | null,
+): ClassProgress => {
+  const step = normalizeClassMilestoneStep(stepInput);
+  const totalCandidate = Number(totalXPInput);
+  const totalXP = Number.isFinite(totalCandidate) ? Math.max(0, totalCandidate) : 0;
+  const stars = Math.floor(totalXP / step);
+  const stepXP = totalXP % step;
+  const remainingXP = Math.max(0, step - stepXP);
+  return { totalXP, stars, step, stepXP, remainingXP };
+};
+
+export const computeClassProgress = (students: Student[], settings: Settings): ClassProgress => {
+  const totalXP = Math.max(
+    0,
+    students.reduce((sum, student) => sum + (Number.isFinite(student.xp) ? student.xp : 0), 0),
+  );
+  return calculateClassProgress(totalXP, settings.classMilestoneStep);
+};

--- a/classquest/src/core/gameLogic.ts
+++ b/classquest/src/core/gameLogic.ts
@@ -1,18 +1,18 @@
 import { eventBus } from '@/lib/EventBus';
 import { DEFAULT_SETTINGS } from './config';
+import { calculateClassProgress, normalizeClassMilestoneStep } from './classProgress';
 import { todayKey, levelFromXP } from './xp';
 import { shouldAutoAward } from './selectors/badges';
 import type { Student, Quest, LogEntry, AppState, ID } from '~/types/models';
 
 const getClassMilestoneStep = (state: AppState) =>
-  Math.max(1, state.settings.classMilestoneStep ?? DEFAULT_SETTINGS.classMilestoneStep);
+  normalizeClassMilestoneStep(state.settings.classMilestoneStep ?? DEFAULT_SETTINGS.classMilestoneStep);
 
 const applyClassProgressDelta = (state: AppState, deltaXP: number) => {
   const prev = Math.max(0, state.classProgress?.totalXP ?? 0);
   const totalXP = Math.max(0, prev + deltaXP);
   const step = getClassMilestoneStep(state);
-  const stars = Math.floor(totalXP / step);
-  return { totalXP, stars };
+  return calculateClassProgress(totalXP, step);
 };
 
 const awardStreak = (

--- a/classquest/src/core/schema/appState.ts
+++ b/classquest/src/core/schema/appState.ts
@@ -1,5 +1,6 @@
 import * as z from 'zod';
 import { DEFAULT_SETTINGS } from '../config';
+import { calculateClassProgress } from '../classProgress';
 import { normalizeThemeId } from '~/types/models';
 import { SOUND_KEYS, type SoundKey, type SoundOverride } from '~/audio/types';
 import { normalizeAudioFormat } from '~/audio/format';
@@ -108,6 +109,9 @@ export const Settings = z.object({
 export const ClassProgress = z.object({
   totalXP: z.number().min(0),
   stars: z.number().min(0),
+  step: z.number().min(1),
+  stepXP: z.number().min(0),
+  remainingXP: z.number().min(0),
 });
 
 export const BadgeDefinition = z.object({
@@ -470,11 +474,7 @@ export function sanitizeState(raw: unknown): AppStateType | null {
     0,
     students.reduce((sum, student) => sum + (Number.isFinite(student.xp) ? student.xp : 0), 0),
   );
-  const step = Math.max(1, settings.classMilestoneStep ?? DEFAULT_SETTINGS.classMilestoneStep);
-  const classProgress: AppStateType['classProgress'] = {
-    totalXP,
-    stars: Math.floor(totalXP / step),
-  };
+  const classProgress = calculateClassProgress(totalXP, settings.classMilestoneStep);
 
   const version = Math.max(1, Math.trunc(asNumber(raw.version, 1)) || 1);
   const badgeDefs = sanitizeBadgeDefs(raw.badgeDefs);

--- a/classquest/src/core/selectors/classProgress.ts
+++ b/classquest/src/core/selectors/classProgress.ts
@@ -1,14 +1,30 @@
+import { normalizeClassMilestoneStep } from '~/core/classProgress';
 import type { AppState } from '~/types/models';
 
-const ensureStep = (settings: AppState['settings']) =>
-  Math.max(1, settings.classMilestoneStep ?? 1000);
+const ensureStep = (state: AppState) =>
+  normalizeClassMilestoneStep(
+    state.classProgress?.step ?? state.settings.classMilestoneStep ?? 1000,
+  );
 
 export function selectClassProgress(state: AppState) {
-  const step = ensureStep(state.settings);
   const total = Math.max(0, state.classProgress?.totalXP ?? 0);
-  const stars = Math.floor(total / step);
-  const nextTarget = Math.max(step, (stars + 1) * step);
-  const remaining = Math.max(0, nextTarget - total);
-  const ratio = nextTarget > 0 ? Math.min(1, total / nextTarget) : 0;
-  return { step, total, stars, nextTarget, remaining, ratio };
+  const step = ensureStep(state);
+  const stars = Math.max(0, Math.floor(state.classProgress?.stars ?? total / step));
+  const stepXP = Math.max(0, Math.min(step, state.classProgress?.stepXP ?? (total % step)));
+  const remaining = Math.max(0, state.classProgress?.remainingXP ?? step - stepXP);
+  return { total, step, stars, stepXP, remaining };
+}
+
+export function selectClassProgressView(state: AppState) {
+  const progress = selectClassProgress(state);
+  const pct = Math.min(1, progress.stepXP / Math.max(1, progress.step));
+  return {
+    total: progress.total,
+    stars: progress.stars,
+    step: progress.step,
+    current: progress.stepXP,
+    remaining: progress.remaining,
+    pct,
+    label: `${progress.stepXP} / ${progress.step} XP – noch ${progress.remaining} XP bis zum nächsten Stern`,
+  };
 }

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_SETTINGS } from './config';
+import { calculateClassProgress, normalizeClassMilestoneStep } from './classProgress';
 import { processAward } from './gameLogic';
 import { levelFromXP } from './xp';
 import type {
@@ -64,29 +65,34 @@ const buildTeam = (team: Team, existingStudents: Student[]) => {
 export const createInitialState = (
   settings?: Partial<Settings>,
   version = 1,
-): AppState => ({
-  students: [],
-  teams: [],
-  quests: [],
-  logs: [],
-  settings: (() => {
-    const { flags, ...restSettings } = settings ?? {};
-    const theme = normalizeThemeId(restSettings.theme ?? DEFAULT_SETTINGS.theme, DEFAULT_SETTINGS.theme);
-    return {
-      ...DEFAULT_SETTINGS,
-      ...restSettings,
-      theme,
-      flags: {
-        ...(DEFAULT_SETTINGS.flags ?? {}),
-        ...((flags ?? {}) as Record<string, boolean>),
-      },
-    } satisfies Settings;
-  })(),
-  version,
-  classProgress: { totalXP: 0, stars: 0 },
-  badgeDefs: [],
-  categories: [],
-});
+): AppState => {
+  const { flags, ...restSettings } = settings ?? {};
+  const theme = normalizeThemeId(restSettings.theme ?? DEFAULT_SETTINGS.theme, DEFAULT_SETTINGS.theme);
+  const normalizedSettings: Settings = {
+    ...DEFAULT_SETTINGS,
+    ...restSettings,
+    theme,
+    flags: {
+      ...(DEFAULT_SETTINGS.flags ?? {}),
+      ...((flags ?? {}) as Record<string, boolean>),
+    },
+  };
+  normalizedSettings.classMilestoneStep = normalizeClassMilestoneStep(
+    normalizedSettings.classMilestoneStep,
+  );
+
+  return {
+    students: [],
+    teams: [],
+    quests: [],
+    logs: [],
+    settings: normalizedSettings,
+    version,
+    classProgress: calculateClassProgress(0, normalizedSettings.classMilestoneStep),
+    badgeDefs: [],
+    categories: [],
+  };
+};
 
 type StudentInput = {
   id: ID;

--- a/classquest/src/types/models.ts
+++ b/classquest/src/types/models.ts
@@ -76,6 +76,9 @@ export type LogEntry = {
 export type ClassProgress = {
   totalXP: number;
   stars: number;
+  step: number;
+  stepXP: number;
+  remainingXP: number;
 };
 
 export type Settings = {

--- a/classquest/src/ui/components/ClassProgressBar.tsx
+++ b/classquest/src/ui/components/ClassProgressBar.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { useApp } from '~/app/AppContext';
-import { selectClassProgress } from '~/core/selectors/classProgress';
+import { selectClassProgressView } from '~/core/selectors/classProgress';
 import { getObjectURL } from '~/services/blobStore';
 
 const numberFormatter = new Intl.NumberFormat('de-DE');
 
 export function ClassProgressBar() {
   const { state } = useApp();
-  const { step, total, stars, nextTarget, remaining, ratio } = selectClassProgress(state);
+  const view = selectClassProgressView(state);
   const starLabel = state.settings.classStarsName ?? 'Stern';
-  const percent = Math.round(ratio * 100);
+  const percent = Math.round(view.pct * 100);
+  const formattedCurrent = numberFormatter.format(view.current);
+  const formattedStep = numberFormatter.format(view.step);
+  const formattedRemaining = numberFormatter.format(view.remaining);
+  const formattedStars = numberFormatter.format(view.stars);
   const [starIconUrl, setStarIconUrl] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -47,27 +51,22 @@ export function ClassProgressBar() {
         border: '1px solid rgba(15,23,42,0.08)',
         display: 'flex',
         flexDirection: 'column',
-        gap: 12,
+        gap: 16,
       }}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', gap: 16 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16 }}>
         <div>
           <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Klassen-XP</h2>
-          <p style={{ margin: '4px 0 0', color: 'rgba(15,23,42,0.68)', fontSize: 14 }} aria-live="polite">
-            {numberFormatter.format(total)} / {numberFormatter.format(nextTarget)} XP · noch{' '}
-            {numberFormatter.format(remaining)} XP bis zum nächsten {starLabel}
+          <p style={{ margin: '6px 0 0', color: 'rgba(15,23,42,0.7)', fontSize: 14 }} aria-live="polite">
+            {formattedCurrent} / {formattedStep} XP – noch {formattedRemaining} XP bis zum nächsten {starLabel}
           </p>
         </div>
         <div
-          style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 26, fontWeight: 700, color: '#047857' }}
-          aria-label="Gesammelte Sterne"
+          style={{ display: 'flex', alignItems: 'center', gap: 12 }}
+          aria-label={`Gesammelte ${starLabel}: ${formattedStars}`}
         >
-          {starIconUrl ? (
-            <img src={starIconUrl} alt="" aria-hidden style={{ width: 28, height: 28, objectFit: 'contain' }} />
-          ) : (
-            <span aria-hidden>⭐</span>
-          )}
-          <span>{numberFormatter.format(stars)}</span>
+          <StarBadge iconUrl={starIconUrl} />
+          <span style={{ fontSize: 28, fontWeight: 700, color: '#047857' }}>{formattedStars}</span>
         </div>
       </div>
       <div
@@ -78,9 +77,9 @@ export function ClassProgressBar() {
         aria-valuetext={`${percent}%`}
         style={{
           position: 'relative',
-          height: 12,
+          height: 14,
           borderRadius: 999,
-          background: 'rgba(15,23,42,0.08)',
+          background: 'rgba(15,23,42,0.1)',
           overflow: 'hidden',
         }}
       >
@@ -89,12 +88,48 @@ export function ClassProgressBar() {
             width: `${percent}%`,
             height: '100%',
             borderRadius: 999,
-            background: 'linear-gradient(90deg, rgba(16,185,129,0.9), rgba(5,150,105,1))',
-            transition: 'width 160ms ease-out',
+            background: 'linear-gradient(90deg, rgba(16,185,129,1), rgba(5,150,105,0.9))',
+            boxShadow: '0 0 12px rgba(16,185,129,0.45)',
+            transition: 'width 300ms ease',
           }}
         />
       </div>
-      <div style={{ fontSize: 12, color: 'rgba(15,23,42,0.6)' }}>Stern-Schrittgröße: {numberFormatter.format(step)} XP</div>
+      <div style={{ fontSize: 12, color: 'rgba(15,23,42,0.6)' }}>Schrittgröße: {formattedStep} XP</div>
     </section>
+  );
+}
+
+function StarBadge({ iconUrl }: { iconUrl: string | null }) {
+  if (iconUrl) {
+    return (
+      <img
+        src={iconUrl}
+        alt=""
+        aria-hidden
+        style={{
+          width: 32,
+          height: 32,
+          objectFit: 'contain',
+          filter: 'drop-shadow(0 4px 12px rgba(255,210,107,0.6))',
+        }}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'inline-block',
+        width: 32,
+        height: 32,
+        background: 'conic-gradient(from 0deg, #ffd26b, #fff2a1, #ffd26b)',
+        filter: 'drop-shadow(0 4px 12px rgba(255,210,107,0.65))',
+        WebkitMaskImage:
+          "url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 24 24%22><path fill=%22black%22 d=%22M12 2l2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 17.8 6.2 20.9l1.1-6.5L2.6 8.8l6.5-.9z%22/></svg>')",
+        WebkitMaskSize: 'contain',
+        WebkitMaskRepeat: 'no-repeat',
+      }}
+    />
   );
 }

--- a/classquest/src/ui/screens/DashboardScreen.tsx
+++ b/classquest/src/ui/screens/DashboardScreen.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useApp } from '~/app/AppContext';
-import { selectClassProgress } from '~/core/selectors/classProgress';
+import { selectClassProgressView } from '~/core/selectors/classProgress';
 import { ClassProgressBar } from '~/ui/components/ClassProgressBar';
 import '~/ui/screens/dashboard.css';
 
@@ -24,8 +24,8 @@ function formatTimestamp(timestamp: number) {
   }
 }
 
-function SegmentedXpBar({ total, step }: { total: number; step: number }) {
-  const progress = step > 0 ? Math.min(1, (total % step) / step) : 0;
+function SegmentedXpBar({ current, step }: { current: number; step: number }) {
+  const progress = step > 0 ? Math.min(1, current / step) : 0;
   const percent = Math.round(progress * 100);
   return (
     <div className="dashboard-xpbar" aria-label="Fortschritt zum nächsten Stern">
@@ -60,7 +60,7 @@ function StarRow({ stars }: { stars: number }) {
 
 export default function DashboardScreen({ onAddXp, onOpenWeeklyShow }: DashboardScreenProps) {
   const { state } = useApp();
-  const classProgress = selectClassProgress(state);
+  const classProgress = selectClassProgressView(state);
   const aliasById = useMemo(
     () => new Map(state.students.map((student) => [student.id, student.alias])),
     [state.students],
@@ -74,7 +74,7 @@ export default function DashboardScreen({ onAddXp, onOpenWeeklyShow }: Dashboard
 
   const remaining = numberFormatter.format(Math.max(0, classProgress.remaining));
   const step = numberFormatter.format(classProgress.step);
-  const segmentTotal = numberFormatter.format(classProgress.total % classProgress.step);
+  const segmentTotal = numberFormatter.format(classProgress.current);
 
   return (
     <div className="dashboard">
@@ -113,7 +113,7 @@ export default function DashboardScreen({ onAddXp, onOpenWeeklyShow }: Dashboard
               XP hinzufügen
             </button>
           </header>
-          <SegmentedXpBar total={classProgress.total} step={classProgress.step} />
+          <SegmentedXpBar current={classProgress.current} step={classProgress.step} />
           <StarRow stars={classProgress.stars} />
           <ClassProgressBar />
         </section>

--- a/classquest/src/ui/screens/ManageScreen.tsx
+++ b/classquest/src/ui/screens/ManageScreen.tsx
@@ -2408,6 +2408,27 @@ export default function ManageScreen({ onOpenSeasonReset }: ManageScreenProps = 
             />
             Negative XP erlauben (Shop kann unter 0 gehen)
           </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+            <span style={{ fontWeight: 600 }}>XP pro Klassen-Stern</span>
+            <input
+              type="number"
+              min={1}
+              step={10}
+              value={state.settings.classMilestoneStep}
+              onChange={(e) => {
+                const numeric = Number.parseInt(e.target.value, 10);
+                const step = Number.isFinite(numeric) ? Math.max(1, numeric) : 1;
+                dispatch({ type: 'UPDATE_SETTINGS', updates: { classMilestoneStep: step } });
+              }}
+              style={{
+                width: 120,
+                padding: '8px 10px',
+                borderRadius: 10,
+                border: '1px solid #cbd5f5',
+              }}
+            />
+            <span style={{ fontSize: 12, color: '#475569' }}>Bestimmt die XP bis zum nächsten Klassen-Stern</span>
+          </label>
           <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <input
               type="checkbox"

--- a/classquest/tests/classProgress.test.ts
+++ b/classquest/tests/classProgress.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { calculateClassProgress } from '~/core/classProgress';
+
+const compute = (totalXP: number, step: number) => {
+  const progress = calculateClassProgress(totalXP, step);
+  const pct = progress.step > 0 ? progress.stepXP / progress.step : 0;
+  return {
+    stars: progress.stars,
+    stepXP: progress.stepXP,
+    remainingXP: progress.remainingXP,
+    pct,
+  };
+};
+
+describe('Class progress math', () => {
+  it('starts from 0 each milestone', () => {
+    const step = 1000;
+    expect(compute(0, step)).toMatchObject({ stars: 0, stepXP: 0, remainingXP: 1000, pct: 0 });
+    expect(compute(999, step)).toMatchObject({ stars: 0, stepXP: 999, remainingXP: 1 });
+    expect(compute(1000, step)).toMatchObject({ stars: 1, stepXP: 0, remainingXP: 1000, pct: 0 });
+    expect(compute(1999, step)).toMatchObject({ stars: 1, stepXP: 999, remainingXP: 1 });
+    expect(compute(2000, step)).toMatchObject({ stars: 2, stepXP: 0, remainingXP: 1000 });
+  });
+
+  it('handles custom step sizes', () => {
+    const step = 750;
+    expect(compute(1125, step)).toMatchObject({ stars: 1, stepXP: 375, remainingXP: 375 });
+  });
+});

--- a/classquest/tests/gameLogic.test.ts
+++ b/classquest/tests/gameLogic.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { eventBus } from '@/lib/EventBus';
 import { processAward } from '~/core/gameLogic';
+import { calculateClassProgress } from '~/core/classProgress';
 import type { AppState, Quest, Student } from '~/types/models';
 
 const createStudent = (overrides: Partial<Student> = {}): Student => ({
@@ -17,6 +18,7 @@ const createStudent = (overrides: Partial<Student> = {}): Student => ({
 const createState = (studentOverrides: Partial<Student> = {}): AppState => {
   const student = createStudent(studentOverrides);
   const totalXP = Math.max(0, student.xp);
+  const classMilestoneStep = 1000;
   return {
     students: [student],
     teams: [],
@@ -28,9 +30,12 @@ const createState = (studentOverrides: Partial<Student> = {}): AppState => {
       xpPerLevel: 100,
       streakThresholdForBadge: 2,
       allowNegativeXP: false,
+      classMilestoneStep,
+      classStarIconKey: null,
+      classStarsName: 'Stern',
     },
     version: 1,
-    classProgress: { totalXP, stars: Math.floor(totalXP / 1000) },
+    classProgress: calculateClassProgress(totalXP, classMilestoneStep),
     badgeDefs: [],
   };
 };
@@ -112,6 +117,9 @@ describe('processAward', () => {
         xpPerLevel: 100,
         streakThresholdForBadge: 2,
         allowNegativeXP: true,
+        classMilestoneStep: 1000,
+        classStarIconKey: null,
+        classStarsName: 'Stern',
       },
     } satisfies AppState;
     const emitSpy = vi.spyOn(eventBus, 'emit');

--- a/classquest/tests/storage.test.ts
+++ b/classquest/tests/storage.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { LocalStorageAdapter, STORAGE_KEY } from '~/services/storage/localStorage';
 import type { AppState } from '~/types/models';
 import { sanitizeState } from '~/core/schema/appState';
+import { calculateClassProgress } from '~/core/classProgress';
 
 type GlobalWithStorage = typeof globalThis & { localStorage?: Storage };
 
@@ -43,9 +44,12 @@ const sampleState = (): AppState => ({
     xpPerLevel: 100,
     streakThresholdForBadge: 5,
     allowNegativeXP: false,
+    classMilestoneStep: 1000,
+    classStarIconKey: null,
+    classStarsName: 'Stern',
   },
   version: 1,
-  classProgress: { totalXP: 10, stars: 0 },
+  classProgress: calculateClassProgress(10, 1000),
   badgeDefs: [],
 });
 


### PR DESCRIPTION
## Summary
- add a shared class progress utility that normalizes milestone steps and exposes remaining XP data
- update selectors and UI components to render per-star progress with a larger glowing star display and refreshed text
- surface the milestone step input on the manage screen and extend unit coverage for the modulo math and related flows

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68daa8c84d28832cb746c58b07c67232