### PR TITLE
Prioritize award sounds to avoid overlapping playback

### DIFF
--- a/classquest/src/audio/useSoundSettings.tsx
+++ b/classquest/src/audio/useSoundSettings.tsx
@@ -9,6 +9,7 @@ import {
 import type { PropsWithChildren, JSX } from 'react';
 import { soundManager } from './SoundManager';
 import { queueAppSound } from './soundQueue';
+import type { AppSoundEvent } from './soundQueue';
 import type { SoundSettings } from './types';
 import { eventBus } from '@/lib/EventBus';
 
@@ -91,14 +92,51 @@ export function SoundSettingsProvider({ children }: PropsWithChildren): JSX.Elem
   }, [settings.volume]);
 
   useEffect(() => {
-    const offXp = eventBus.on('xp:granted', () => queueAppSound('xp_awarded'));
-    const offLevel = eventBus.on('level:up', () => queueAppSound('level_up'));
-    const offBadge = eventBus.on('badge:awarded', () => queueAppSound('badge_award'));
+    const HOLD_MS = 175;
+    const PRIORITY: Record<AppSoundEvent, number> = {
+      xp_awarded: 1,
+      level_up: 2,
+      badge_award: 3,
+    };
+
+    let pending: { evt: AppSoundEvent; prio: number } | null = null;
+    let timer: ReturnType<typeof window.setTimeout> | null = null;
+
+    const flush = () => {
+      if (!pending) return;
+      queueAppSound(pending.evt);
+      pending = null;
+      if (timer) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+    };
+
+    const schedule = (evt: AppSoundEvent) => {
+      const prio = PRIORITY[evt];
+      if (!pending || prio > pending.prio) {
+        pending = { evt, prio };
+      }
+      if (timer == null) {
+        timer = window.setTimeout(() => {
+          flush();
+        }, HOLD_MS);
+      }
+    };
+
+    const offXp = eventBus.on('xp:granted', () => schedule('xp_awarded'));
+    const offLevel = eventBus.on('level:up', () => schedule('level_up'));
+    const offBadge = eventBus.on('badge:awarded', () => schedule('badge_award'));
 
     return () => {
       offXp();
       offLevel();
       offBadge();
+      if (timer != null) {
+        window.clearTimeout(timer);
+      }
+      pending = null;
+      timer = null;
     };
   }, []);
 

--- a/classquest/src/core/state.ts
+++ b/classquest/src/core/state.ts
@@ -258,13 +258,13 @@ export const awardQuest = (state: AppState, { questId, studentId, teamId, note }
     const gainedBadge = (after.badges?.length ?? 0) > (before.badges?.length ?? 0);
     const leveledUp = after.level > before.level;
 
-    queueAppSound('xp_awarded', timestamp);
-    if (leveledUp) {
-      queueAppSound('level_up', timestamp);
-    }
-    if (gainedBadge) {
-      queueAppSound('badge_award', timestamp);
-    }
+    const prioritizedEvent = gainedBadge
+      ? 'badge_award'
+      : leveledUp
+        ? 'level_up'
+        : 'xp_awarded';
+
+    queueAppSound(prioritizedEvent, timestamp);
 
     return { state: nextState, changed: true };
   };

--- a/classquest/tests/soundPriorityThrottle.test.ts
+++ b/classquest/tests/soundPriorityThrottle.test.ts
@@ -54,6 +54,56 @@ describe('sound priority and throttling', () => {
     expect(soundManager.play).toHaveBeenCalledWith('badge-award');
   });
 
+  it('plays only the level sound when a quest causes a level up', async () => {
+    let state = createInitialState();
+    state = addStudent(state, { id: 's1', alias: 'Alice', xp: 90 });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 20,
+      type: 'repeatable',
+      target: 'individual',
+      active: true,
+    });
+
+    state = awardQuest(state, { questId: 'q1', studentId: 's1' });
+
+    await advance(200);
+
+    expect(soundManager.play).toHaveBeenCalledTimes(1);
+    expect(soundManager.play).toHaveBeenCalledWith('level-up');
+  });
+
+  it('plays only the badge sound when a quest grants a new badge', async () => {
+    let state = createInitialState();
+    state = {
+      ...state,
+      badgeDefs: [
+        {
+          id: 'total-120',
+          name: 'Total XP 120',
+          rule: { type: 'total_xp', threshold: 120 },
+        },
+      ],
+    };
+    state = addStudent(state, { id: 's1', alias: 'Alice', xp: 110 });
+    state = addQuest(state, {
+      id: 'q1',
+      name: 'Quest',
+      xp: 15,
+      type: 'repeatable',
+      target: 'individual',
+      active: true,
+    });
+
+    state = awardQuest(state, { questId: 'q1', studentId: 's1' });
+
+    await advance(200);
+
+    expect(soundManager.play).toHaveBeenCalledTimes(1);
+    expect(soundManager.play).toHaveBeenCalledWith('badge-award');
+  });
+
   it('throttles repeated xp events while still awarding xp', async () => {
     let state = createInitialState();
     state = addStudent(state, { id: 's1', alias: 'Alice' });


### PR DESCRIPTION
## Summary
- ensure quest awards queue only the highest priority sound so badges and levels override xp
- debounce event bus sound listeners to keep xp playback from firing when more important events follow
- extend the sound priority test suite to cover level-up and badge award scenarios

## Testing
- npm run test -- tests/soundPriorityThrottle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e254718344832c9b2d595d160c24e6