### PR TITLE
feat: add data-driven theming system

### DIFF
--- a/classquest/index.html
+++ b/classquest/index.html
@@ -4,6 +4,19 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script>
+      (() => {
+        try {
+          const raw = localStorage.getItem('cq_theme');
+          const s = raw ? JSON.parse(raw) : null;
+          if (s?.theme) document.documentElement.setAttribute('data-theme', s.theme);
+          if (s?.accent) document.documentElement.setAttribute('data-accent', s.accent);
+          if (s?.bg) document.documentElement.setAttribute('data-bg', s.bg);
+        } catch (error) {
+          console.warn('[ClassQuest] Failed to hydrate theme pre-render', error);
+        }
+      })();
+    </script>
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/classquest/package-lock.json
+++ b/classquest/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.12",
+        "framer-motion": "^12.23.22",
         "howler": "^2.2.4",
         "lottie-web": "^5.13.0",
         "lucide-react": "^0.544.0",
@@ -2789,6 +2790,33 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.22",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.22.tgz",
+      "integrity": "sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.21",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3388,6 +3416,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.21",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.21.tgz",
+      "integrity": "sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4248,6 +4291,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/classquest/package.json
+++ b/classquest/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.13.12",
+    "framer-motion": "^12.23.22",
     "howler": "^2.2.4",
     "lottie-web": "^5.13.0",
     "lucide-react": "^0.544.0",

--- a/classquest/public/bg/starfield.svg
+++ b/classquest/public/bg/starfield.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="240" viewBox="0 0 240 240">
+  <rect width="240" height="240" fill="#050915" />
+  <g fill="#22d3ee" opacity="0.55">
+    <circle cx="32" cy="28" r="1.5" />
+    <circle cx="120" cy="54" r="1" />
+    <circle cx="200" cy="96" r="1.8" />
+    <circle cx="82" cy="142" r="1.2" />
+    <circle cx="30" cy="184" r="1.6" />
+    <circle cx="176" cy="210" r="1.4" />
+  </g>
+  <g fill="#fb923c" opacity="0.45">
+    <circle cx="64" cy="92" r="1.1" />
+    <circle cx="188" cy="44" r="1.4" />
+    <circle cx="148" cy="168" r="1.2" />
+    <circle cx="32" cy="132" r="1" />
+  </g>
+  <g fill="#e5e7eb" opacity="0.8">
+    <circle cx="24" cy="48" r="0.8" />
+    <circle cx="104" cy="22" r="0.6" />
+    <circle cx="228" cy="66" r="0.7" />
+    <circle cx="96" cy="198" r="0.6" />
+    <circle cx="210" cy="182" r="0.8" />
+    <circle cx="54" cy="218" r="0.6" />
+  </g>
+  <g stroke="#ffffff" stroke-width="0.4" opacity="0.45">
+    <line x1="0" y1="120" x2="240" y2="120" stroke-dasharray="1 11" />
+    <line x1="120" y1="0" x2="120" y2="240" stroke-dasharray="1 9" />
+  </g>
+</svg>

--- a/classquest/public/bg/treasure.svg
+++ b/classquest/public/bg/treasure.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320">
+  <rect width="320" height="320" fill="#f9f5e7" />
+  <g stroke="#d4a373" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.55">
+    <path d="M24 60c40 32 64 28 100 12s64-12 100 20 60 44 72 20" />
+    <path d="M12 200c32-20 64-18 84-4s52 18 68-10 44-40 80-28 44 2 64-20" />
+  </g>
+  <g stroke="#b45309" stroke-dasharray="6 10" stroke-width="2" fill="none" opacity="0.45">
+    <path d="M60 36c22 26 52 46 86 48s76-12 118 46" />
+    <path d="M36 244c48 16 76 8 102-18s54-30 106-6" />
+  </g>
+  <g fill="#b91c1c" opacity="0.8">
+    <path d="M70 48l6 10 10 6-10 6-6 10-6-10-10-6 10-6z" />
+    <path d="M250 90l6 10 10 6-10 6-6 10-6-10-10-6 10-6z" />
+    <path d="M112 228l6 10 10 6-10 6-6 10-6-10-10-6 10-6z" />
+  </g>
+  <g fill="#f59e0b" opacity="0.65">
+    <circle cx="36" cy="120" r="6" />
+    <circle cx="214" cy="214" r="5" />
+    <circle cx="280" cy="156" r="7" />
+    <circle cx="140" cy="288" r="6" />
+  </g>
+</svg>

--- a/classquest/src/App.css
+++ b/classquest/src/App.css
@@ -146,6 +146,16 @@
   gap: 12px;
 }
 
+.topbar-theme {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg) 86%, rgba(255, 255, 255, 0.08));
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
 .topbar-button {
   display: inline-flex;
   align-items: center;

--- a/classquest/src/App.tsx
+++ b/classquest/src/App.tsx
@@ -4,19 +4,17 @@ import {
   HelpCircle,
   Info,
   LayoutDashboard,
-  Moon,
   PlaySquare,
   Search,
   Settings,
   Sparkles,
-  Sun,
   Target,
   Users2,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import ThemeProvider from '@/theme/ThemeProvider';
 import AppShell from '@/components/layout/AppShell';
-import '@/styles/theme.css';
+import '@/styles/globals.css';
 import '@/styles/starfield.css';
 import './App.css';
 import { useApp } from '~/app/AppContext';
@@ -39,7 +37,8 @@ import {
   EVENT_SELECT_ALL,
   EVENT_UNDO_PERFORMED,
 } from '~/ui/shortcut/events';
-import type { ThemeId } from '~/types/models';
+import ThemeToggle from '@/components/ui/ThemeToggle';
+import AccentSelect from '@/components/ui/AccentSelect';
 import { KEYBOARD_TAB_ORDER, type AppTab } from '~/types/navigation';
 
 type NavItem = {
@@ -178,15 +177,6 @@ export default function App() {
     setResetOpen(true);
   }, []);
 
-  const handleThemeToggle = useCallback(() => {
-    const themes: ThemeId[] = ['space', 'light', 'dark'];
-    const current = state.settings.theme ?? 'space';
-    const nextIndex = (themes.indexOf(current) + 1) % themes.length;
-    const nextTheme = themes[nextIndex];
-    dispatch({ type: 'UPDATE_SETTINGS', updates: { theme: nextTheme } });
-    feedback.info(nextTheme === 'space' ? 'Theme: Space' : nextTheme === 'light' ? 'Theme: Hell' : 'Theme: Dunkel');
-  }, [dispatch, feedback, state.settings.theme]);
-
   const openWeeklyShow = useCallback(() => {
     const url = new URL(window.location.href);
     url.pathname = '/show';
@@ -196,13 +186,6 @@ export default function App() {
   const handleAddXpShortcut = useCallback(() => {
     setTab('rewards');
   }, []);
-
-  const themeIcon = useMemo(() => {
-    const current = state.settings.theme ?? 'space';
-    return current === 'dark' ? Sun : Moon;
-  }, [state.settings.theme]);
-
-  const ThemeIcon = themeIcon;
 
   return (
     <ThemeProvider>
@@ -284,9 +267,10 @@ export default function App() {
                   <PlaySquare size={18} aria-hidden />
                   <span className="topbar-button__label">Weekly Show</span>
                 </button>
-                <button type="button" className="icon-button" onClick={handleThemeToggle} aria-label="Theme wechseln">
-                  <ThemeIcon size={18} aria-hidden />
-                </button>
+                <div className="topbar-theme">
+                  <ThemeToggle />
+                  <AccentSelect />
+                </div>
                 <button type="button" className="icon-button" onClick={() => setHelpOpen(true)} aria-label="Hilfe anzeigen">
                   <HelpCircle size={18} aria-hidden />
                 </button>

--- a/classquest/src/components/chrome/AppBackground.tsx
+++ b/classquest/src/components/chrome/AppBackground.tsx
@@ -1,0 +1,52 @@
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { backgrounds } from '@/config/theme.config';
+import { useTheme } from '@/theme/useTheme';
+
+export default function AppBackground() {
+  const { bg } = useTheme();
+  const background = backgrounds.find((definition) => definition.id === bg);
+  const reduceMotion = useReducedMotion();
+
+  if (!background || background.id === 'none') {
+    return null;
+  }
+
+  const transition = reduceMotion ? { duration: 0 } : { duration: 0.24 };
+
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: 'fixed',
+        inset: 0,
+        pointerEvents: 'none',
+        zIndex: -10,
+      }}
+    >
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.div
+          key={background.id}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 0.25 }}
+          exit={{ opacity: 0 }}
+          transition={transition}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage: `url(${background.asset})`,
+            backgroundRepeat: 'repeat',
+            backgroundSize: 'auto',
+          }}
+        />
+      </AnimatePresence>
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: 'radial-gradient(120% 120% at 50% -10%, transparent, rgba(0,0,0,0.35))',
+        }}
+      />
+    </div>
+  );
+}

--- a/classquest/src/components/layout/AppShell.tsx
+++ b/classquest/src/components/layout/AppShell.tsx
@@ -1,14 +1,22 @@
 import { useApp } from '@/app/AppContext';
+import AppBackground from '@/components/chrome/AppBackground';
+import { useTheme } from '@/theme/useTheme';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const { state } = useApp();
   const animations = state.settings?.animationsEnabled ?? true;
+  const { bg } = useTheme();
+  const showLegacyWallpaper = bg === 'none';
 
   return (
-    <div className="relative min-h-screen" style={{ background: 'var(--bg)', color: 'var(--text)' }}>
-      <div className="wallpaper-underlay" aria-hidden />
-      {animations && <div className="star-sky" aria-hidden />}
-      <div className="relative z-10">{children}</div>
+    <div
+      className="app-shell"
+      style={{ background: 'var(--bg)', color: 'var(--text)', minHeight: '100vh', position: 'relative' }}
+    >
+      <AppBackground />
+      {showLegacyWallpaper && <div className="wallpaper-underlay" aria-hidden />}
+      {animations && showLegacyWallpaper && <div className="star-sky" aria-hidden />}
+      <div style={{ position: 'relative', zIndex: 10 }}>{children}</div>
     </div>
   );
 }

--- a/classquest/src/components/ui/AccentSelect.tsx
+++ b/classquest/src/components/ui/AccentSelect.tsx
@@ -1,0 +1,22 @@
+import { useTheme } from '@/theme/useTheme';
+
+export default function AccentSelect() {
+  const { accent, setAccent, accents } = useTheme();
+
+  return (
+    <div className="accent-swatch-group" role="group" aria-label="Akzentfarbe wählen">
+      {accents.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          className="accent-swatch"
+          style={{ background: option.value }}
+          data-active={accent === option.id}
+          onClick={() => setAccent(option.id)}
+          aria-pressed={accent === option.id}
+          aria-label={option.label}
+        />
+      ))}
+    </div>
+  );
+}

--- a/classquest/src/components/ui/ThemeToggle.tsx
+++ b/classquest/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,52 @@
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from '@/theme/useTheme';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const isLight = theme === 'light';
+  const shouldReduceMotion = useReducedMotion();
+
+  const handleToggle = () => {
+    setTheme(isLight ? 'dark' : 'light');
+  };
+
+  const transition = shouldReduceMotion ? { duration: 0 } : { duration: 0.2 };
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      onClick={handleToggle}
+      aria-pressed={isLight}
+      aria-label={isLight ? 'Lichtmodus aktiv' : 'Dunkelmodus aktiv'}
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        {isLight ? (
+          <motion.span
+            key="sun"
+            initial={{ rotate: -90, opacity: 0 }}
+            animate={{ rotate: 0, opacity: 1 }}
+            exit={{ rotate: 90, opacity: 0 }}
+            transition={transition}
+            aria-hidden
+          >
+            <Sun height={18} width={18} />
+          </motion.span>
+        ) : (
+          <motion.span
+            key="moon"
+            initial={{ rotate: -90, opacity: 0 }}
+            animate={{ rotate: 0, opacity: 1 }}
+            exit={{ rotate: 90, opacity: 0 }}
+            transition={transition}
+            aria-hidden
+          >
+            <Moon height={18} width={18} />
+          </motion.span>
+        )}
+      </AnimatePresence>
+      <span className="theme-toggle__label">{isLight ? 'Light' : 'Dark'}</span>
+    </button>
+  );
+}

--- a/classquest/src/config/theme.config.ts
+++ b/classquest/src/config/theme.config.ts
@@ -1,0 +1,25 @@
+export const themes = [
+  { id: 'dark', label: 'Dark' },
+  { id: 'light', label: 'Light' },
+] as const;
+
+export const accents = [
+  { id: 'electricBlue', label: 'Electric Blue', value: '#22d3ee' },
+  { id: 'vividOrange', label: 'Vivid Orange', value: '#fb923c' },
+  { id: 'magentaPop', label: 'Magenta Pop', value: '#e879f9' },
+  { id: 'emerald', label: 'Emerald', value: '#34d399' },
+] as const;
+
+export const backgrounds = [
+  { id: 'none', label: 'None' },
+  { id: 'starfield', label: 'Starfield', asset: '/bg/starfield.svg' },
+  { id: 'treasure', label: 'Treasure Map', asset: '/bg/treasure.svg' },
+] as const;
+
+export type ThemeId = typeof themes[number]['id'];
+export type AccentId = typeof accents[number]['id'];
+export type BackgroundId = typeof backgrounds[number]['id'];
+
+export const defaultTheme: ThemeId = 'dark';
+export const defaultAccent: AccentId = 'electricBlue';
+export const defaultBackground: BackgroundId = 'starfield';

--- a/classquest/src/styles/globals.css
+++ b/classquest/src/styles/globals.css
@@ -1,0 +1,123 @@
+@import './theme.css';
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family:
+    'Inter',
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  text-rendering: optimizeLegibility;
+}
+
+:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  body,
+  .card,
+  .sidebar,
+  .topbar,
+  .theme-toggle,
+  .accent-swatch,
+  .btn-accent {
+    transition: background-color 200ms ease, color 200ms ease,
+      border-color 200ms ease, box-shadow 200ms ease;
+  }
+}
+
+.card {
+  background: var(--card);
+  color: var(--card-fg);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.25);
+}
+
+.btn-accent {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 9999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.btn-accent:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.ring-accent {
+  --tw-ring-color: color-mix(in oklab, var(--accent), transparent 50%);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--surface-glass);
+  color: inherit;
+  cursor: pointer;
+}
+
+.theme-toggle span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.theme-toggle__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.accent-swatch-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.accent-swatch {
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+  cursor: pointer;
+  position: relative;
+}
+
+.accent-swatch:focus-visible {
+  outline: 3px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.accent-swatch[data-active='true']::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: inherit;
+  border: 2px solid var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 60%);
+}
+
+[data-bg='none'] .app-shell::before {
+  opacity: 0;
+}

--- a/classquest/src/styles/theme.css
+++ b/classquest/src/styles/theme.css
@@ -1,25 +1,80 @@
-:root {
-  --bg: #0b0f1a;
-  --card: #12182a;
-  --text: #e6f0ff;
-  --accent: #ffa62b;
-  --accent-2: #6ad5ff;
-  --muted: #8ea2c2;
-  --ring: #ffd26b;
+:root,
+:root[data-theme='dark'] {
+  --bg: #0b1220;
+  --bg-rgb: 11 18 32;
+  --fg: #e5e7eb;
+  --fg-rgb: 229 231 235;
+  --muted: #9aa4b2;
+  --muted-rgb: 154 164 178;
+  --card: #0f172a;
+  --card-rgb: 15 23 42;
+  --card-fg: #e5e7eb;
+  --card-fg-rgb: 229 231 235;
+  --ring: #22d3ee;
+  --ring-rgb: 34 211 238;
+  --accent: #22d3ee;
+  --accent-rgb: 34 211 238;
+  --success: #10b981;
+  --success-rgb: 16 185 129;
+  --warning: #f59e0b;
+  --warning-rgb: 245 158 11;
+  --info: #60a5fa;
+  --info-rgb: 96 165 250;
+  --surface-glass: color-mix(in srgb, var(--bg) 85%, transparent);
+  --text: var(--fg);
+  --accent-2: color-mix(in oklab, var(--accent) 70%, white 30%);
 }
 
-html[data-theme="space"] {
-  --bg: #070b16;
-  --card: #0e1528;
-  --text: #e9f2ff;
-  --accent: #ffa62b;
-  --accent-2: #6ad5ff;
-  --muted: #8ea2c2;
-  --ring: #ffd26b;
+:root[data-theme='light'] {
+  --bg: #f8fafc;
+  --bg-rgb: 248 250 252;
+  --fg: #0f172a;
+  --fg-rgb: 15 23 42;
+  --muted: #475569;
+  --muted-rgb: 71 85 105;
+  --card: #ffffff;
+  --card-rgb: 255 255 255;
+  --card-fg: #0f172a;
+  --card-fg-rgb: 15 23 42;
+  --ring: #2563eb;
+  --ring-rgb: 37 99 235;
+  --accent: #ef4444;
+  --accent-rgb: 239 68 68;
+  --success: #16a34a;
+  --success-rgb: 22 163 74;
+  --warning: #f59e0b;
+  --warning-rgb: 245 158 11;
+  --info: #2563eb;
+  --info-rgb: 37 99 235;
+  --surface-glass: color-mix(in srgb, var(--bg) 92%, rgba(15, 23, 42, 0.08));
+  --text: var(--fg);
+  --accent-2: color-mix(in oklab, var(--accent) 60%, #2563eb 40%);
 }
 
-/* Optional: Platzhalter für andere Themes */
-html[data-theme="dark"] { }
-html[data-theme="light"] { }
+:root[data-accent='electricBlue'] {
+  --accent: #22d3ee;
+  --accent-rgb: 34 211 238;
+  --ring: #22d3ee;
+  --ring-rgb: 34 211 238;
+}
 
-body { background: var(--bg); color: var(--text); }
+:root[data-accent='vividOrange'] {
+  --accent: #fb923c;
+  --accent-rgb: 251 146 60;
+  --ring: #fb923c;
+  --ring-rgb: 251 146 60;
+}
+
+:root[data-accent='magentaPop'] {
+  --accent: #e879f9;
+  --accent-rgb: 232 121 249;
+  --ring: #e879f9;
+  --ring-rgb: 232 121 249;
+}
+
+:root[data-accent='emerald'] {
+  --accent: #34d399;
+  --accent-rgb: 52 211 153;
+  --ring: #34d399;
+  --ring-rgb: 52 211 153;
+}

--- a/classquest/src/theme/ThemeProvider.tsx
+++ b/classquest/src/theme/ThemeProvider.tsx
@@ -1,33 +1,128 @@
-import { useEffect } from 'react';
-import { useApp } from '@/app/AppContext';
-import { normalizeThemeId, type ThemeId } from '@/types/models';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  accents,
+  backgrounds,
+  defaultAccent,
+  defaultBackground,
+  defaultTheme,
+  themes,
+} from '@/config/theme.config';
 
-export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const { state } = useApp();
+interface ThemeState {
+  theme: (typeof themes)[number]['id'];
+  accent: (typeof accents)[number]['id'];
+  bg: (typeof backgrounds)[number]['id'];
+}
+
+type ThemeContextValue = ThemeState & {
+  setTheme: (theme: ThemeState['theme']) => void;
+  setAccent: (accent: ThemeState['accent']) => void;
+  setBg: (bg: ThemeState['bg']) => void;
+  themes: typeof themes;
+  accents: typeof accents;
+  bgs: typeof backgrounds;
+  cycleAccent: () => void;
+  isMounted: boolean;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+const STORAGE_KEY = 'cq_theme';
+
+const getInitialState = (): ThemeState => ({
+  theme: defaultTheme,
+  accent: defaultAccent,
+  bg: defaultBackground,
+});
+
+const readStoredState = (): Partial<ThemeState> | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as Partial<ThemeState>;
+    return parsed;
+  } catch (error) {
+    console.warn('[ThemeProvider] Failed to parse stored theme state', error);
+    return null;
+  }
+};
+
+const applyStateToRoot = (state: ThemeState) => {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const root = document.documentElement;
+  root.setAttribute('data-theme', state.theme);
+  root.setAttribute('data-accent', state.accent);
+  root.setAttribute('data-bg', state.bg);
+};
+
+export const ThemeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [state, setState] = useState<ThemeState>(getInitialState);
+  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
-    const root = document.documentElement;
-    const configured = normalizeThemeId(state.settings?.theme, 'space');
+    const stored = readStoredState();
+    if (stored) {
+      setState((prev) => ({
+        theme: stored.theme ?? prev.theme,
+        accent: stored.accent ?? prev.accent,
+        bg: stored.bg ?? prev.bg,
+      }));
+    }
+    setIsMounted(true);
+  }, []);
 
+  useEffect(() => {
+    applyStateToRoot(state);
     if (typeof window === 'undefined') {
-      root.setAttribute('data-theme', configured === 'system' ? 'space' : configured);
       return;
     }
-
-    if (configured === 'system') {
-      const media = window.matchMedia('(prefers-color-scheme: dark)');
-      const apply = () => {
-        const next: ThemeId = media.matches ? 'dark' : 'light';
-        root.setAttribute('data-theme', next);
-      };
-      apply();
-      media.addEventListener('change', apply);
-      return () => media.removeEventListener('change', apply);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      console.warn('[ThemeProvider] Failed to persist theme state', error);
     }
+  }, [state]);
 
-    root.setAttribute('data-theme', configured);
-    return;
-  }, [state.settings?.theme]);
+  const value = useMemo<ThemeContextValue>(() => {
+    const setTheme = (theme: ThemeState['theme']) =>
+      setState((prev) => ({ ...prev, theme }));
+    const setAccent = (accent: ThemeState['accent']) =>
+      setState((prev) => ({ ...prev, accent }));
+    const setBg = (bg: ThemeState['bg']) => setState((prev) => ({ ...prev, bg }));
+    const cycleAccent = () => {
+      const index = accents.findIndex((accentDef) => accentDef.id === state.accent);
+      const next = accents[(index + 1) % accents.length]?.id ?? accents[0]!.id;
+      setState((prev) => ({ ...prev, accent: next }));
+    };
 
-  return <>{children}</>;
-}
+    return {
+      ...state,
+      setTheme,
+      setAccent,
+      setBg,
+      themes,
+      accents,
+      bgs: backgrounds,
+      cycleAccent,
+      isMounted,
+    };
+  }, [state, isMounted]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useThemeContext = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return ctx;
+};
+
+export default ThemeProvider;

--- a/classquest/src/theme/useTheme.ts
+++ b/classquest/src/theme/useTheme.ts
@@ -1,0 +1,1 @@
+export { useThemeContext as useTheme } from './ThemeProvider';

--- a/classquest/tailwind.config.ts
+++ b/classquest/tailwind.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from 'tailwindcss';
+
+const config = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        bg: 'rgb(var(--bg-rgb) / <alpha-value>)',
+        fg: 'rgb(var(--fg-rgb) / <alpha-value>)',
+        muted: 'rgb(var(--muted-rgb) / <alpha-value>)',
+        card: 'rgb(var(--card-rgb) / <alpha-value>)',
+        'card-fg': 'rgb(var(--card-fg-rgb) / <alpha-value>)',
+        accent: 'rgb(var(--accent-rgb) / <alpha-value>)',
+        success: 'rgb(var(--success-rgb) / <alpha-value>)',
+        warning: 'rgb(var(--warning-rgb) / <alpha-value>)',
+        info: 'rgb(var(--info-rgb) / <alpha-value>)',
+      },
+      ringColor: {
+        DEFAULT: 'rgb(var(--ring-rgb) / 0.5)',
+      },
+      borderColor: {
+        DEFAULT: 'rgb(255 255 255 / 0.06)',
+      },
+      boxShadow: {
+        'lg/10': '0 10px 25px rgba(0,0,0,0.10)',
+        'xl/10': '0 20px 35px rgba(0,0,0,0.10)',
+      },
+      borderRadius: {
+        '2xl': '1rem',
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;
+
+export default config;


### PR DESCRIPTION
## Summary
- add a centralized theme configuration with CSS tokens and Tailwind mappings for accents, themes, and backgrounds
- replace the legacy theme provider with a persistent hook-driven implementation and expose new toggle/select UI in the top bar
- introduce animated app backgrounds, preload state via an anti-FOUC script, and add supporting assets/styles

## Testing
- npm run typecheck *(fails: pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e25af88c64832cafffbd1ace2ad582