### PR TITLE
Polish student detail layout spacing and accent controls

### DIFF
--- a/classquest/src/components/ui/AccentSelect.tsx
+++ b/classquest/src/components/ui/AccentSelect.tsx
@@ -15,6 +15,7 @@ export default function AccentSelect() {
           onClick={() => setAccent(option.id)}
           aria-pressed={accent === option.id}
           aria-label={option.label}
+          title={option.label}
         />
       ))}
     </div>

--- a/classquest/src/styles/globals.css
+++ b/classquest/src/styles/globals.css
@@ -98,24 +98,31 @@ body {
   width: 1.9rem;
   height: 1.9rem;
   border-radius: 999px;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(15, 23, 42, 0.18);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.28);
   cursor: pointer;
   position: relative;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.accent-swatch:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.32);
 }
 
 .accent-swatch:focus-visible {
   outline: 3px solid var(--ring);
   outline-offset: 2px;
+  transform: translateY(-1px);
 }
 
 .accent-swatch[data-active='true']::after {
   content: '';
   position: absolute;
-  inset: -4px;
+  inset: -3px;
   border-radius: inherit;
   border: 2px solid var(--accent);
-  box-shadow: 0 0 0 4px color-mix(in oklab, var(--accent), transparent 60%);
+  box-shadow: 0 0 0 6px color-mix(in oklab, var(--accent), transparent 72%);
 }
 
 [data-bg='none'] .app-shell::before {

--- a/classquest/src/ui/components/AwardBadgeButton.tsx
+++ b/classquest/src/ui/components/AwardBadgeButton.tsx
@@ -8,15 +8,22 @@ type AwardBadgeButtonProps = {
 };
 
 const buttonStyle: CSSProperties = {
-  borderRadius: 12,
-  border: '1px solid #cbd5f5',
-  background: '#fff',
-  padding: '8px 12px',
+  borderRadius: 999,
+  border: '1.5px solid var(--accent)',
+  background: 'color-mix(in oklab, var(--accent), transparent 92%)',
+  padding: '10px 16px',
   fontSize: 13,
   fontWeight: 600,
-  color: '#1e293b',
+  color: 'var(--accent)',
   cursor: 'pointer',
-  boxShadow: '0 6px 14px rgba(15,23,42,0.08)',
+  boxShadow: '0 10px 24px rgba(15,23,42,0.08)',
+  transition: 'background 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease',
+};
+
+const buttonHoverStyle: CSSProperties = {
+  background: 'color-mix(in oklab, var(--accent), transparent 86%)',
+  boxShadow: '0 14px 32px rgba(15,23,42,0.14)',
+  transform: 'translateY(-1px)',
 };
 
 const popoverStyle: CSSProperties = {
@@ -63,6 +70,7 @@ const optionDescriptionStyle: CSSProperties = {
 export default function AwardBadgeButton({ student }: AwardBadgeButtonProps) {
   const { state, dispatch } = useApp();
   const [open, setOpen] = useState(false);
+  const [hovered, setHovered] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
   const badgeDefs = useMemo(() => {
@@ -102,10 +110,14 @@ export default function AwardBadgeButton({ student }: AwardBadgeButtonProps) {
     <div ref={containerRef} style={{ position: 'relative', display: 'inline-flex' }}>
       <button
         type="button"
-        style={buttonStyle}
+        style={{ ...buttonStyle, ...(hovered ? buttonHoverStyle : undefined) }}
         onClick={() => setOpen((value) => !value)}
         aria-haspopup="listbox"
         aria-expanded={open}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}
       >
         🏅 Badge vergeben
       </button>

--- a/classquest/src/ui/components/badges/TrophyGrid.tsx
+++ b/classquest/src/ui/components/badges/TrophyGrid.tsx
@@ -4,16 +4,17 @@ import type { Badge } from '~/types/models';
 
 const tileStyle: React.CSSProperties = {
   position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  justifyContent: 'center',
-  gap: 12,
-  padding: 16,
-  borderRadius: 18,
+  display: 'grid',
+  gridTemplateRows: '1fr auto',
+  placeItems: 'center',
+  gap: 10,
+  width: 120,
+  height: 120,
+  padding: 14,
+  borderRadius: 20,
   border: '1px solid rgba(148,163,184,0.35)',
-  background: 'linear-gradient(180deg, rgba(248,250,252,0.85), rgba(226,232,240,0.75))',
-  boxShadow: '0 16px 40px rgba(15,23,42,0.12)',
+  background: 'linear-gradient(180deg, rgba(248,250,252,0.92), rgba(226,232,240,0.82))',
+  boxShadow: '0 16px 36px rgba(15,23,42,0.12)',
   transition: 'transform 0.18s ease, box-shadow 0.18s ease',
 };
 
@@ -34,10 +35,14 @@ const tooltipStyle: React.CSSProperties = {
 };
 
 const captionStyle: React.CSSProperties = {
-  fontSize: 14,
+  fontSize: 13,
   fontWeight: 600,
   color: '#0f172a',
   textAlign: 'center',
+  maxWidth: '100%',
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
 };
 
 type TrophyGridProps = {
@@ -77,11 +82,20 @@ function TrophyTile({ badge }: { badge: Badge }) {
         style={{
           ...tileStyle,
           transform: hover ? 'translateY(-4px) scale(1.02)' : 'translateY(0)',
-          boxShadow: hover ? '0 22px 50px rgba(14,116,144,0.25)' : tileStyle.boxShadow,
+          boxShadow: hover ? '0 22px 48px rgba(14,116,144,0.22)' : tileStyle.boxShadow,
           cursor: 'pointer',
         }}
       >
-        <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={88} />
+        <div
+          style={{
+            width: 64,
+            height: 64,
+            display: 'grid',
+            placeItems: 'center',
+          }}
+        >
+          <BadgeIcon name={badge.name} iconKey={badge.iconKey} size={64} />
+        </div>
         <span style={captionStyle}>{badge.name}</span>
       </button>
       <div
@@ -128,8 +142,8 @@ export function TrophyGrid({ badges, emptyMessage = 'Noch keine Abzeichen – st
         margin: 0,
         padding: 0,
         display: 'grid',
-        gap: 18,
-        gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+        gap: 16,
+        gridTemplateColumns: 'repeat(auto-fit, minmax(120px, 1fr))',
       }}
     >
       {sortedBadges.map((badge) => (

--- a/classquest/src/ui/components/student/StudentProfileCardV2.tsx
+++ b/classquest/src/ui/components/student/StudentProfileCardV2.tsx
@@ -104,10 +104,12 @@ export function StudentProfileCardV2({
         padding: '6px 14px',
         borderRadius: 999,
         background: 'linear-gradient(90deg, #f97316, #fb7185)',
-        color: '#fff',
+        color: 'rgba(15,23,42,0.85)',
         fontWeight: 700,
         fontSize: 14,
-        boxShadow: '0 12px 28px rgba(249,115,22,0.35)',
+        boxShadow:
+          '0 0 0 1px rgba(15,23,42,0.18), 0 12px 28px rgba(249,115,22,0.35)',
+        textShadow: '0 1px 0 rgba(255,255,255,0.45)',
       }}
     >
       Level {student.level}
@@ -120,7 +122,7 @@ export function StudentProfileCardV2({
       style={{
         display: 'grid',
         gap: 24,
-        padding: 28,
+        padding: 'clamp(24px, 4vw, 32px)',
         borderRadius: 32,
         border: '1px solid rgba(148,163,184,0.35)',
         background: 'linear-gradient(180deg, rgba(15,23,42,0.9), rgba(15,23,42,0.82))',
@@ -174,7 +176,7 @@ export function StudentProfileCardV2({
             flex: '1 1 280px',
             minWidth: 240,
             display: 'grid',
-            gap: 18,
+            gap: 16,
             alignContent: 'start',
           }}
         >
@@ -206,18 +208,31 @@ export function StudentProfileCardV2({
             </div>
             {levelPill}
           </div>
-          <div style={{ display: 'grid', gap: 10 }}>
-            <div style={{ fontSize: 14, color: 'rgba(226,232,240,0.9)' }}>
-              {formatNumber(progress.inLevel)} / {formatNumber(xpPerLevel)} XP in diesem Level
+          <div style={{ display: 'grid', gap: 16 }}>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                gap: 12,
+                fontSize: 14,
+                color: 'rgba(226,232,240,0.85)',
+              }}
+            >
+              <span>Level-Fortschritt</span>
+              <span style={{ fontWeight: 600, color: '#f8fafc' }}>
+                {formatNumber(progress.inLevel)} / {formatNumber(xpPerLevel)} XP
+              </span>
             </div>
             <div
               aria-hidden
               style={{
                 height: 14,
                 borderRadius: 999,
-                background: 'rgba(30,41,59,0.65)',
+                background: 'rgba(15,23,42,0.16)',
                 overflow: 'hidden',
-                border: '1px solid rgba(148,163,184,0.45)',
+                border: '1px solid rgba(15,23,42,0.24)',
               }}
             >
               <div
@@ -225,8 +240,9 @@ export function StudentProfileCardV2({
                   width: `${Math.round(progress.ratio * 100)}%`,
                   height: '100%',
                   borderRadius: 999,
-                  background: 'linear-gradient(90deg, #22d3ee, #38bdf8)',
-                  boxShadow: '0 12px 28px rgba(8,145,178,0.45)',
+                  background:
+                    'linear-gradient(90deg, var(--accent), color-mix(in oklab, var(--accent), white 12%))',
+                  boxShadow: '0 10px 24px rgba(34,211,238,0.25)',
                 }}
               />
             </div>
@@ -238,7 +254,7 @@ export function StudentProfileCardV2({
             style={{
               display: 'flex',
               flexWrap: 'wrap',
-              gap: 12,
+              gap: 16,
               alignItems: 'center',
             }}
           >
@@ -264,11 +280,11 @@ export function StudentProfileCardV2({
       </div>
 
       <section style={{ display: 'grid', gap: 10 }}>
-        <h2 style={{ margin: 0, fontSize: 18, color: '#e2e8f0' }}>Top-Kategorien</h2>
+        <h2 style={{ margin: 0, fontSize: 18, lineHeight: '1.6', color: '#e2e8f0' }}>Top-Kategorien</h2>
         {topCategories.length === 0 ? (
           <p style={{ margin: 0, color: 'rgba(226,232,240,0.75)' }}>Noch keine Kategorien vergeben.</p>
         ) : (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10 }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12 }}>
             {topCategories.map((entry) => {
               const ratio = categoriesTotal > 0 ? Math.round((entry.xp / categoriesTotal) * 100) : 0;
               return (

--- a/classquest/src/ui/screens/ClassOverviewScreen.tsx
+++ b/classquest/src/ui/screens/ClassOverviewScreen.tsx
@@ -39,14 +39,21 @@ type ProfilePaneProps = {
 
 const containerStyle: CSSProperties = { display: 'flex', height: '100%', minHeight: 0 };
 const sidebarStyle: CSSProperties = {
-  width: 280,
-  padding: '18px 16px',
-  borderRight: '1px solid #d0d7e6',
-  background: '#f1f5f9',
+  width: 292,
+  padding: '24px 18px',
+  borderRight: '1px solid rgba(148,163,184,0.35)',
+  background: 'rgba(248,250,252,0.82)',
+  backdropFilter: 'blur(12px)',
+  boxShadow: 'inset -1px 0 0 rgba(15,23,42,0.08)',
   overflowY: 'auto',
 };
 const listStyle: CSSProperties = { listStyle: 'none', margin: 0, padding: 0, display: 'grid', gap: 8 };
-const mainStyle: CSSProperties = { flex: 1, minWidth: 0, overflowY: 'auto', padding: 24 };
+const mainStyle: CSSProperties = {
+  flex: 1,
+  minWidth: 0,
+  overflowY: 'auto',
+  padding: '28px clamp(20px, 4vw, 36px)',
+};
 const detailsStyle: CSSProperties = {
   background: '#fff',
   borderRadius: 24,
@@ -132,7 +139,9 @@ export default function ClassOverviewScreen() {
   return (
     <div style={containerStyle}>
       <aside style={sidebarStyle}>
-        <h2 style={{ margin: '0 0 12px', fontSize: 18 }}>Klassenübersicht</h2>
+        <h2 style={{ margin: '0 0 16px', fontSize: 18, lineHeight: '1.6', color: '#0f172a' }}>
+          Klassenübersicht
+        </h2>
         {students.length === 0 ? (
           <p style={{ margin: 0, color: '#475569' }}>Noch keine Schüler angelegt.</p>
         ) : (
@@ -147,16 +156,21 @@ export default function ClassOverviewScreen() {
                     onClick={() => setSelectedId(student.id)}
                     style={{
                       width: '100%',
-                      borderRadius: 14,
-                      border: '1px solid #cbd5f5',
-                      padding: '10px 12px',
-                      background: selected ? '#dbeafe' : '#fff',
+                      borderRadius: 18,
+                      border: '1px solid rgba(148,163,184,0.35)',
+                      padding: '12px 14px',
+                      background: selected ? 'rgba(219,234,254,0.9)' : 'rgba(255,255,255,0.7)',
+                      backdropFilter: 'blur(10px)',
                       cursor: 'pointer',
                       textAlign: 'left',
                       display: 'flex',
                       alignItems: 'center',
-                      gap: 12,
-                      boxShadow: selected ? '0 6px 18px rgba(37, 99, 235, 0.18)' : 'none',
+                      gap: 14,
+                      boxShadow: selected
+                        ? '0 12px 30px rgba(37,99,235,0.18)'
+                        : '0 6px 16px rgba(15,23,42,0.06)',
+                      transition: 'background 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease',
+                      transform: selected ? 'translateY(-1px)' : 'translateY(0)',
                     }}
                   >
                     <AvatarView
@@ -171,8 +185,10 @@ export default function ClassOverviewScreen() {
                       rounded="xl"
                     />
                     <div style={{ minWidth: 0 }}>
-                      <div style={{ fontWeight: 600, fontSize: 15, marginBottom: 2 }}>{student.alias}</div>
-                      <div style={{ fontSize: 12, color: '#475569' }}>
+                      <div style={{ fontWeight: 600, fontSize: 15, marginBottom: 2, color: '#0f172a' }}>
+                        {student.alias}
+                      </div>
+                      <div style={{ fontSize: 12, color: 'rgba(71,85,105,0.9)' }}>
                         {formatNumber(student.xp)} XP · Level {student.level}
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- increase breathing room and progress clarity on the student profile card, including inline XP totals and a refreshed level badge
- normalize trophy tiles and adjust the class list sidebar for clearer hierarchy and contrast
- align supporting UI controls with the accent system, including the badge award button and accent picker hover states

## Testing
- npm run lint *(fails: repository lacks an eslint.config file in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25f52ffa4832c8d17fd7185b8673a