### PR TITLE
Add weekly class goal rocket to weekly show slide

### DIFF
--- a/classquest/src/ui/components/ClassProgressBar.tsx
+++ b/classquest/src/ui/components/ClassProgressBar.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { useApp } from '~/app/AppContext';
 import { selectClassProgressView } from '~/core/selectors/classProgress';
 import { getObjectURL } from '~/services/blobStore';
-
-const numberFormatter = new Intl.NumberFormat('de-DE');
+import {
+  classProgressNumberFormatter,
+  getFormattedClassProgressCopy,
+} from '~/ui/components/classProgressFormatting';
 
 export function ClassProgressBar() {
   const { state } = useApp();
   const view = selectClassProgressView(state);
   const starLabel = state.settings.classStarsName ?? 'Stern';
   const percent = Math.round(view.pct * 100);
-  const formattedCurrent = numberFormatter.format(view.current);
-  const formattedStep = numberFormatter.format(view.step);
-  const formattedRemaining = numberFormatter.format(view.remaining);
-  const formattedStars = numberFormatter.format(view.stars);
+  const { formattedCurrent, formattedStep, formattedRemaining, announcement } =
+    getFormattedClassProgressCopy(view, starLabel);
+  const formattedStars = classProgressNumberFormatter.format(view.stars);
   const [starIconUrl, setStarIconUrl] = React.useState<string | null>(null);
 
   React.useEffect(() => {
@@ -58,7 +59,7 @@ export function ClassProgressBar() {
         <div>
           <h2 style={{ margin: 0, fontSize: 20, fontWeight: 700 }}>Klassen-XP</h2>
           <p style={{ margin: '6px 0 0', color: 'rgba(15,23,42,0.7)', fontSize: 14 }} aria-live="polite">
-            {formattedCurrent} / {formattedStep} XP – noch {formattedRemaining} XP bis zum nächsten {starLabel}
+            {announcement}
           </p>
         </div>
         <div

--- a/classquest/src/ui/components/classProgressFormatting.ts
+++ b/classquest/src/ui/components/classProgressFormatting.ts
@@ -1,0 +1,16 @@
+export const classProgressNumberFormatter = new Intl.NumberFormat('de-DE');
+
+export function getFormattedClassProgressCopy(
+  view: { current: number; step: number; remaining: number },
+  starLabel: string,
+) {
+  const formattedCurrent = classProgressNumberFormatter.format(view.current);
+  const formattedStep = classProgressNumberFormatter.format(view.step);
+  const formattedRemaining = classProgressNumberFormatter.format(view.remaining);
+  return {
+    formattedCurrent,
+    formattedStep,
+    formattedRemaining,
+    announcement: `${formattedCurrent} / ${formattedStep} XP – noch ${formattedRemaining} XP bis zum nächsten ${starLabel}`,
+  };
+}

--- a/classquest/src/ui/show/WeeklyClassGoalRocket.tsx
+++ b/classquest/src/ui/show/WeeklyClassGoalRocket.tsx
@@ -1,0 +1,115 @@
+import { motion } from 'framer-motion';
+import React from 'react';
+import { useApp } from '~/app/AppContext';
+import { selectClassProgressView } from '~/core/selectors/classProgress';
+import { getFormattedClassProgressCopy } from '~/ui/components/classProgressFormatting';
+
+const rocketSvg = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 240" preserveAspectRatio="xMidYMid meet">
+  <path d="M60 6c-14 22-24 66-24 108v44L18 196v34l42-14 42 14v-34l-18-38v-44C84 72 74 28 60 6Z" fill="black"/>
+  <path d="M36 158c-6 12-16 20-24 24v40l48-32Z" fill="black"/>
+  <path d="M84 158c6 12 16 20 24 24v40l-48-32Z" fill="black"/>
+</svg>`;
+
+const rocketMask = `url("data:image/svg+xml,${encodeURIComponent(rocketSvg)}")`;
+
+const fillTransition = { type: 'spring', stiffness: 140, damping: 20, mass: 0.6 };
+
+export default function WeeklyClassGoalRocket() {
+  const { state } = useApp();
+  const view = selectClassProgressView(state);
+  const starLabel = state.settings.classStarsName ?? 'Stern';
+  const { formattedCurrent, formattedStep, formattedRemaining, announcement } =
+    getFormattedClassProgressCopy(view, starLabel);
+  const pct = Math.max(0, Math.min(1, view.pct));
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 12,
+        justifyItems: 'center',
+        padding: 16,
+        borderRadius: 20,
+        background: 'rgba(15,23,42,0.35)',
+        border: '1px solid rgba(148,163,184,0.18)',
+        maxWidth: 220,
+        margin: '0 auto',
+      }}
+    >
+      <div
+        role="img"
+        aria-label={announcement}
+        style={{
+          position: 'relative',
+          width: 140,
+          height: 240,
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            WebkitMaskImage: rocketMask,
+            maskImage: rocketMask,
+            WebkitMaskRepeat: 'no-repeat',
+            maskRepeat: 'no-repeat',
+            WebkitMaskSize: 'contain',
+            maskSize: 'contain',
+            background: 'rgba(15,23,42,0.35)',
+            filter: 'drop-shadow(0 14px 32px rgba(56,189,248,0.35))',
+          }}
+        />
+        <motion.div
+          aria-hidden
+          initial={{ scaleY: 0 }}
+          animate={{ scaleY: pct }}
+          transition={fillTransition}
+          style={{
+            position: 'absolute',
+            inset: 0,
+            transformOrigin: 'center bottom',
+            WebkitMaskImage: rocketMask,
+            maskImage: rocketMask,
+            WebkitMaskRepeat: 'no-repeat',
+            maskRepeat: 'no-repeat',
+            WebkitMaskSize: 'contain',
+            maskSize: 'contain',
+            background:
+              'linear-gradient(180deg, rgba(96,165,250,0.05) 0%, rgba(56,189,248,0.85) 45%, rgba(14,165,233,0.95) 100%)',
+          }}
+        />
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            inset: 0,
+            WebkitMaskImage: rocketMask,
+            maskImage: rocketMask,
+            WebkitMaskRepeat: 'no-repeat',
+            maskRepeat: 'no-repeat',
+            WebkitMaskSize: 'contain',
+            maskSize: 'contain',
+            border: '2px solid rgba(226,232,240,0.65)',
+            borderRadius: 0,
+            boxSizing: 'border-box',
+          }}
+        />
+      </div>
+      <div
+        aria-live="polite"
+        style={{
+          display: 'grid',
+          gap: 4,
+          textAlign: 'center',
+          color: '#e2e8f0',
+        }}
+      >
+        <strong style={{ fontSize: 20, letterSpacing: 0.4 }}>{formattedCurrent} / {formattedStep} XP</strong>
+        <span style={{ fontSize: 13, opacity: 0.85 }}>
+          Noch {formattedRemaining} XP bis zum nächsten {starLabel}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/classquest/src/ui/show/WeeklyShowSlide.tsx
+++ b/classquest/src/ui/show/WeeklyShowSlide.tsx
@@ -3,6 +3,7 @@ import { useApp } from '~/app/AppContext';
 import { AvatarView } from '~/ui/avatar/AvatarView';
 import { BadgeIcon } from '~/ui/components/BadgeIcon';
 import EvolutionSequence from '~/ui/show/EvolutionSequence';
+import WeeklyClassGoalRocket from '~/ui/show/WeeklyClassGoalRocket';
 import type { WeeklyDelta } from '~/core/show/weekly';
 
 const AVATAR_SIZE = 220;
@@ -187,42 +188,60 @@ export default function WeeklyShowSlide({ data, durationMs = 12000 }: WeeklyShow
             </span>
             <h2 style={{ margin: 0, fontSize: 36 }}>{student.alias}</h2>
           </div>
-          <div style={{ display: 'grid', gap: 12 }}>
+          <div
+            style={{
+              display: 'grid',
+              gap: 16,
+              gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+              alignItems: 'stretch',
+            }}
+          >
             <div
               style={{
-                ...metricStyle,
                 opacity: phase === 'intro' ? 0 : 1,
                 transform: phase === 'intro' ? 'translateY(12px)' : 'translateY(0)',
                 transition: 'opacity 0.5s ease, transform 0.5s ease',
               }}
             >
-              <span style={{ fontSize: 14, opacity: 0.75 }}>XP</span>
-              <strong style={{ fontSize: 28 }}>
-                {xpGain > 0 ? `+${formatNumber(xpGain)} XP` : 'Keine neuen XP'}
-              </strong>
-              <span style={{ fontSize: 14, opacity: 0.75 }}>
-                {formatNumber(data.xpStart)} → {formatNumber(data.xpEnd)}
-              </span>
+              <WeeklyClassGoalRocket />
             </div>
-            <div
-              style={{
-                ...metricStyle,
-                opacity: phase === 'level' || phase === 'badges' || phase === 'done' ? 1 : 0,
-                transform:
-                  phase === 'level' || phase === 'badges' || phase === 'done'
-                    ? 'translateY(0)'
-                    : 'translateY(12px)',
-                transition: 'opacity 0.5s ease, transform 0.5s ease',
-              }}
-            >
-              <span style={{ fontSize: 14, opacity: 0.75 }}>Level</span>
-              <strong style={{ fontSize: 28 }}>
-                {data.levelStart} → {data.levelEnd}
-              </strong>
-              <span style={{ fontSize: 14, opacity: 0.75 }}>
-                {levelGain > 0 ? `+${levelGain} Level` : 'Stufe gehalten'}
-              </span>
-              {evolved && <span style={{ fontSize: 13, color: '#fde047' }}>Avatar ist eine Stufe aufgestiegen!</span>}
+            <div style={{ display: 'grid', gap: 12 }}>
+              <div
+                style={{
+                  ...metricStyle,
+                  opacity: phase === 'intro' ? 0 : 1,
+                  transform: phase === 'intro' ? 'translateY(12px)' : 'translateY(0)',
+                  transition: 'opacity 0.5s ease, transform 0.5s ease',
+                }}
+              >
+                <span style={{ fontSize: 14, opacity: 0.75 }}>XP</span>
+                <strong style={{ fontSize: 28 }}>
+                  {xpGain > 0 ? `+${formatNumber(xpGain)} XP` : 'Keine neuen XP'}
+                </strong>
+                <span style={{ fontSize: 14, opacity: 0.75 }}>
+                  {formatNumber(data.xpStart)} → {formatNumber(data.xpEnd)}
+                </span>
+              </div>
+              <div
+                style={{
+                  ...metricStyle,
+                  opacity: phase === 'level' || phase === 'badges' || phase === 'done' ? 1 : 0,
+                  transform:
+                    phase === 'level' || phase === 'badges' || phase === 'done'
+                      ? 'translateY(0)'
+                      : 'translateY(12px)',
+                  transition: 'opacity 0.5s ease, transform 0.5s ease',
+                }}
+              >
+                <span style={{ fontSize: 14, opacity: 0.75 }}>Level</span>
+                <strong style={{ fontSize: 28 }}>
+                  {data.levelStart} → {data.levelEnd}
+                </strong>
+                <span style={{ fontSize: 14, opacity: 0.75 }}>
+                  {levelGain > 0 ? `+${levelGain} Level` : 'Stufe gehalten'}
+                </span>
+                {evolved && <span style={{ fontSize: 13, color: '#fde047' }}>Avatar ist eine Stufe aufgestiegen!</span>}
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add a reusable WeeklyClassGoalRocket component that animates class milestone progress with accessible text updates
- share class progress number formatting to keep copy consistent across components
- integrate the rocket visualization into the weekly show slide layout alongside the existing stats

## Testing
- npm run lint *(fails: ESLint couldn't find an eslint.config file; existing configuration appears to use the older .eslintrc format)*

------
https://chatgpt.com/codex/tasks/task_e_68e2653cc03c832ca544a600f5313484