### PR TITLE
Add celebratory avatar evolution effects

### DIFF
--- a/classquest/docs/ui-student-view.md
+++ b/classquest/docs/ui-student-view.md
@@ -7,3 +7,13 @@ Die Schüleransicht unterstützt folgende Shortcuts:
 - **Enter/Leertaste auf dem Avatar**: Öffnet den Avatar-Zoom.
 
 Die Navigation funktioniert nur, wenn kein Texteingabefeld fokussiert ist.
+
+## Avatar-Entwicklung
+
+Die aktuelle Evolutionssequenz kombiniert ein leichtes Schütteln, einen kurzen Weißblitz und eine einfache Überblendung zwischen altem und neuem Avatar.【F:classquest/src/ui/show/EvolutionSequence.tsx†L20-L109】 Dadurch bleibt die Animation performant und funktioniert ohne zusätzliche Abhängigkeiten direkt in React. Wenn wir künftig einen größeren „Level-up“-Moment inszenieren möchten, könnten wir mehrere Aspekte aus der vorgeschlagenen Qt-Umsetzung adaptieren:
+
+- **Aufwendigere Übergänge**: Das dort vorgesehene Crossfade mit OutBack-Skalierung ließe sich als CSS- bzw. Web-Animation nachbauen, um dem Avatar beim Einblenden mehr Dynamik zu geben.
+- **Partikel-Effekte**: Eine leichte Konfetti-Burst-Animation könnte mit einer Canvas- oder WebGL-Schicht (z. B. `react-confetti` oder einer kleinen eigenen Partikel-Engine) ergänzt werden, ohne dass sie nach der Sequenz weiter rendert.
+- **Begleitende Effekte**: Optionaler Glow oder ein kurzer Soundeffekt (etwa über die bestehende Audio-Infrastruktur) würden den Meilenstein stärker hervorheben, sollten aber abschaltbar bleiben, damit die Ansicht im Unterricht nicht zu laut oder ablenkend wirkt.
+
+Bevor wir zusätzliche Effekte einbauen, müssten wir sicherstellen, dass sie auf den vorhandenen Endgeräten flüssig laufen und keine Accessibility-Aspekte (z. B. „reduced motion“) verletzen. Die Qt-Variante zeigt aber, dass eine reichhaltigere Inszenierung technisch möglich ist, sofern wir sie in unsere Webtechnologie übersetzen.

--- a/classquest/src/ui/show/ConfettiBurst.tsx
+++ b/classquest/src/ui/show/ConfettiBurst.tsx
@@ -1,0 +1,212 @@
+import * as React from 'react';
+
+type ConfettiBurstProps = {
+  /** Whether the burst should play. When switching from false to true, a new burst starts. */
+  active: boolean;
+  /** Size (in px) used to size the canvas square. */
+  size: number;
+  /** Optional callback once the animation has fully finished. */
+  onDone?: () => void;
+};
+
+type Particle = {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  rotation: number;
+  vr: number;
+  size: number;
+  color: string;
+  life: number;
+  ttl: number;
+  shape: 'rect' | 'triangle' | 'circle';
+};
+
+const COLORS = ['#ffbf3f', '#ff6fb7', '#66d4ff', '#94f6a7'];
+
+const random = (min: number, max: number) => Math.random() * (max - min) + min;
+
+function createParticles(count: number, centerX: number, centerY: number, radius: number): Particle[] {
+  const particles: Particle[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const angle = random(0, Math.PI * 2);
+    const speed = random(120, 280);
+    const size = random(4, 10);
+    const shapeRand = Math.random();
+    const shape: Particle['shape'] = shapeRand < 0.33 ? 'rect' : shapeRand < 0.66 ? 'triangle' : 'circle';
+
+    particles.push({
+      x: centerX + Math.cos(angle) * radius * random(0, 0.45),
+      y: centerY + Math.sin(angle) * radius * random(0, 0.45),
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      rotation: random(0, Math.PI * 2),
+      vr: random(-5, 5),
+      size,
+      color: COLORS[i % COLORS.length],
+      life: 0,
+      ttl: random(650, 1200),
+      shape,
+    });
+  }
+  return particles;
+}
+
+function drawParticle(ctx: CanvasRenderingContext2D, particle: Particle) {
+  ctx.save();
+  ctx.translate(particle.x, particle.y);
+  ctx.rotate(particle.rotation);
+  ctx.fillStyle = particle.color;
+
+  switch (particle.shape) {
+    case 'triangle': {
+      const s = particle.size;
+      ctx.beginPath();
+      ctx.moveTo(0, -s * 0.6);
+      ctx.lineTo(s * 0.6, s * 0.6);
+      ctx.lineTo(-s * 0.6, s * 0.6);
+      ctx.closePath();
+      ctx.fill();
+      break;
+    }
+    case 'circle': {
+      ctx.beginPath();
+      ctx.arc(0, 0, particle.size * 0.6, 0, Math.PI * 2);
+      ctx.fill();
+      break;
+    }
+    default: {
+      ctx.fillRect(-particle.size / 2, -particle.size / 2, particle.size, particle.size);
+    }
+  }
+
+  ctx.restore();
+}
+
+/**
+ * Lightweight celebratory burst rendered on a canvas. Draws once per activation and disposes.
+ */
+export function ConfettiBurst({ active, size, onDone }: ConfettiBurstProps) {
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null);
+  const animationRef = React.useRef<number>();
+  const particlesRef = React.useRef<Particle[] | null>(null);
+
+  React.useEffect(() => {
+    if (!active) {
+      const canvas = canvasRef.current;
+      if (canvas) {
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
+        }
+      }
+      particlesRef.current = null;
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = undefined;
+      }
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return;
+    }
+
+    const displaySize = size * 1.4;
+    const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
+    canvas.width = displaySize * dpr;
+    canvas.height = displaySize * dpr;
+    canvas.style.width = `${displaySize}px`;
+    canvas.style.height = `${displaySize}px`;
+    const ctxWithReset = ctx as CanvasRenderingContext2D & { resetTransform?: () => void };
+    if (typeof ctxWithReset.resetTransform === 'function') {
+      ctxWithReset.resetTransform();
+    } else {
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+    }
+    ctx.scale(dpr, dpr);
+
+    const origin = displaySize / 2;
+    particlesRef.current = createParticles(120, origin, origin, displaySize / 2);
+
+    const gravity = 420; // px per second^2
+    let lastTime: number | undefined;
+
+    const step = (timestamp: number) => {
+      const particles = particlesRef.current;
+      if (!particles) {
+        return;
+      }
+
+      if (lastTime === undefined) {
+        lastTime = timestamp;
+      }
+
+      const deltaMs = timestamp - lastTime;
+      lastTime = timestamp;
+      const delta = deltaMs / 1000;
+
+      ctx.clearRect(0, 0, displaySize, displaySize);
+
+      let alive = 0;
+      for (const particle of particles) {
+        particle.life += deltaMs;
+        if (particle.life >= particle.ttl) {
+          continue;
+        }
+
+        alive += 1;
+
+        particle.vy += gravity * delta;
+        particle.x += particle.vx * delta;
+        particle.y += particle.vy * delta;
+        particle.rotation += particle.vr * delta;
+
+        const fade = 1 - particle.life / particle.ttl;
+        ctx.globalAlpha = Math.max(0, Math.min(1, fade));
+        drawParticle(ctx, particle);
+        ctx.globalAlpha = 1;
+      }
+
+      if (alive > 0) {
+        animationRef.current = requestAnimationFrame(step);
+      } else {
+        particlesRef.current = null;
+        animationRef.current = undefined;
+        onDone?.();
+      }
+    };
+
+    animationRef.current = requestAnimationFrame(step);
+
+    return () => {
+      if (animationRef.current) {
+        cancelAnimationFrame(animationRef.current);
+        animationRef.current = undefined;
+      }
+    };
+  }, [active, size, onDone]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden="true"
+      style={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        pointerEvents: 'none',
+        mixBlendMode: 'screen',
+      }}
+    />
+  );
+}
+

--- a/classquest/src/ui/show/EvolutionSequence.tsx
+++ b/classquest/src/ui/show/EvolutionSequence.tsx
@@ -3,6 +3,7 @@ import { useApp } from '~/app/AppContext';
 import { AvatarView } from '~/ui/avatar/AvatarView';
 import type { Student } from '~/types/models';
 import { getAvatarStageUrl } from '~/core/show/avatarStageUrl';
+import { ConfettiBurst } from '~/ui/show/ConfettiBurst';
 
 type EvolutionPhase = 'preload' | 'shake' | 'flash' | 'reveal' | 'hold' | 'done';
 
@@ -140,6 +141,7 @@ export default function EvolutionSequence({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    overflow: 'hidden',
   };
 
   const borderRadius = Math.min(size / 2, 24);
@@ -165,6 +167,7 @@ export default function EvolutionSequence({
   }
 
   const revealActive = phase === 'reveal' || phase === 'hold' || phase === 'done';
+  const confettiActive = phase === 'reveal' || phase === 'hold' || phase === 'done';
 
   return (
     <div style={containerStyle}>
@@ -178,13 +181,27 @@ export default function EvolutionSequence({
             bottom: -32,
             left: -32,
             borderRadius: size,
-            background: 'radial-gradient(40% 40% at 50% 50%, rgba(255,220,100,0.28), transparent 60%)',
-            opacity: 0.8,
+            background: 'radial-gradient(40% 40% at 50% 50%, rgba(255,220,100,0.32), transparent 60%)',
+            opacity: phase === 'shake' ? 0.6 : 0.85,
             filter: 'blur(36px)',
             pointerEvents: 'none',
+            transition: 'opacity 300ms ease',
           }}
         />
       )}
+
+      <div
+        aria-hidden="true"
+        className={phase === 'reveal' ? 'evo-glow' : undefined}
+        style={{
+          position: 'absolute',
+          inset: 0,
+          borderRadius,
+          boxShadow: '0 0 0 0 rgba(255, 204, 102, 0.65)',
+          pointerEvents: 'none',
+          mixBlendMode: 'screen',
+        }}
+      />
 
       {previousUrl && (
         <img
@@ -224,9 +241,13 @@ export default function EvolutionSequence({
           style={{
             ...imageStyle,
             opacity: revealActive ? 1 : 0,
+            transform: revealActive ? undefined : 'scale(0.9)',
+            transformOrigin: '50% 50%',
           }}
         />
       )}
+
+      <ConfettiBurst active={confettiActive} size={size} />
 
       <span className="sr-only" aria-live="polite">
         {phase === 'reveal' && 'Avatar hat sich entwickelt.'}
@@ -248,6 +269,9 @@ export default function EvolutionSequence({
         .evo-shake {
           animation: evoShake 600ms ease-in-out both;
         }
+        .evo-glow {
+          animation: evoGlow 1100ms ease-out both;
+        }
         @keyframes evoFlash {
           0% { opacity: 0; }
           20% { opacity: 1; }
@@ -256,8 +280,19 @@ export default function EvolutionSequence({
         .evo-flash {
           animation: evoFlash 250ms ease-out both;
         }
+        @keyframes evoGlow {
+          0% { box-shadow: 0 0 0 0 rgba(255, 204, 102, 0.0); opacity: 0; }
+          25% { box-shadow: 0 0 18px 6px rgba(255, 204, 102, 0.65); opacity: 1; }
+          80% { box-shadow: 0 0 36px 14px rgba(255, 204, 102, 0.4); opacity: 0.4; }
+          100% { box-shadow: 0 0 48px 16px rgba(255, 204, 102, 0.0); opacity: 0; }
+        }
         .evo-reveal {
-          transition: opacity 800ms ease;
+          animation: evoReveal 800ms cubic-bezier(0.175, 0.885, 0.32, 1.275) both;
+        }
+        @keyframes evoReveal {
+          0% { opacity: 0; transform: scale(0.82); filter: drop-shadow(0 0 0 rgba(255, 220, 120, 0)); }
+          50% { opacity: 1; transform: scale(1.08); filter: drop-shadow(0 0 16px rgba(255, 220, 120, 0.45)); }
+          100% { opacity: 1; transform: scale(1); filter: drop-shadow(0 0 6px rgba(255, 220, 120, 0.3)); }
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- add a canvas-driven ConfettiBurst overlay and wire it into the evolution reveal phase
- enrich the EvolutionSequence with glow, overshoot reveal animation, and better crossfade handling

## Testing
- npm run lint *(fails: local environment resolves ESLint 9 which requires the new eslint.config format; repo still provides an .eslintrc configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f294f49c832ca842989c658a4444