### PR TITLE
Enhance weekly slideshow with animations

### DIFF
--- a/classquest/src/ui/show/WeeklyShowPlayer.tsx
+++ b/classquest/src/ui/show/WeeklyShowPlayer.tsx
@@ -3,6 +3,7 @@ import { useApp } from '~/app/AppContext';
 import WeeklyShowSlide from '~/ui/show/WeeklyShowSlide';
 import { computeDeltasFromSnapshot, computeWeeklyDeltas, type WeeklyDelta } from '~/core/show/weekly';
 import { listSnapshots, type WeeklySnapshot } from '~/services/weeklyStorage';
+import { useSlideshowSounds } from '~/slideshow/hooks/useSlideshowSounds';
 
 function formatDateLabel(snapshot: WeeklySnapshot): string {
   const created = new Date(snapshot.createdAt);
@@ -32,6 +33,7 @@ const BACKGROUND_STYLE: React.CSSProperties = {
 
 export default function WeeklyShowPlayer() {
   const { state } = useApp();
+  useSlideshowSounds();
   const [order, setOrder] = React.useState<Order>('delta');
   const [onlyChanged, setOnlyChanged] = React.useState(true);
   const [autoPlay, setAutoPlay] = React.useState(true);


### PR DESCRIPTION
## Summary
- add motion-driven slide, avatar, and badge animations to the weekly slideshow
- trigger slideshow events for avatar reveals and badge fly-ins so accompanying effects can run
- wire the slideshow sound hook into the weekly show player

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272389e6c4832cb8a8efef10da412e)