### PR TITLE
Redesign UI with kid-friendly Duolingo theme

### DIFF
--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -16,12 +16,18 @@ from ui.trophy_cabinet import TrophyCabinetTab
 class MainWindow(QMainWindow):
     def __init__(self, store: Optional[DataStore] = None) -> None:
         super().__init__()
-        self.setWindowTitle("ClassQuest – Kinderfreundliches Dashboard")
-        self.resize(1280, 800)
+        self.setWindowTitle("ClassQuest – Abenteuer wie bei Duolingo")
+        self.resize(1400, 900)
+        self.setStyleSheet(
+            """
+            QMainWindow { background: #F4FDF3; }
+            #tabContainer { margin: 12px; }
+            """
+        )
 
         self.store = store or DataStore(Path("classquest.db"))
 
-        self.tabs = QTabWidget()
+        self.tabs = QTabWidget(objectName="tabContainer")
         self.setCentralWidget(self.tabs)
 
         self.students_tab = StudentsTab(self.store)

--- a/ui/rewards_tab.py
+++ b/ui/rewards_tab.py
@@ -5,6 +5,7 @@ from typing import List
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
+    QFrame,
     QGridLayout,
     QLabel,
     QListWidget,
@@ -14,11 +15,12 @@ from PyQt5.QtWidgets import (
     QSplitter,
     QVBoxLayout,
     QWidget,
+    QHBoxLayout,
 )
 
 from data.models import Reward
 from data.store import DataStore
-from ui.theme import FONT_SIZES, button_style, make_font
+from ui.theme import COLOR_PALETTE, FONT_SIZES, button_style, card_style, make_font
 
 
 class RewardsTab(QWidget):
@@ -28,19 +30,30 @@ class RewardsTab(QWidget):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(16)
+        layout.setSpacing(18)
 
-        header = QLabel("Belohnungen")
-        header.setFont(make_font(FONT_SIZES["heading"], bold=True))
-        layout.addWidget(header)
+        hero = QFrame()
+        hero.setStyleSheet(card_style(COLOR_PALETTE["primary"].name()))
+        hero_layout = QHBoxLayout(hero)
+        hero_layout.setSpacing(12)
+        hero_title = QLabel("🏅 Belohnungen & Jubel")
+        hero_title.setFont(make_font(FONT_SIZES["heading"], bold=True))
+        hero_sub = QLabel("Vergib XP in fröhlichen Farben – genau wie im Lieblings-Lernspiel!")
+        hero_sub.setFont(make_font(FONT_SIZES["body"]))
+        hero_layout.addWidget(hero_title)
+        hero_layout.addWidget(hero_sub)
+        hero_layout.addStretch(1)
+        layout.addWidget(hero)
 
         splitter = QSplitter(Qt.Horizontal)
         splitter.setChildrenCollapsible(False)
         layout.addWidget(splitter, stretch=1)
 
-        left_container = QWidget()
+        left_container = QFrame()
+        left_container.setStyleSheet(card_style(COLOR_PALETTE["sky"].name()))
         left_layout = QVBoxLayout(left_container)
         left_layout.setSpacing(12)
+        left_layout.setContentsMargins(16, 16, 16, 16)
 
         left_label = QLabel("Wähle mehrere Schüler:innen")
         left_label.setFont(make_font(FONT_SIZES["body"], bold=True))
@@ -48,13 +61,16 @@ class RewardsTab(QWidget):
 
         self.student_list = QListWidget()
         self.student_list.setSelectionMode(QListWidget.MultiSelection)
+        self.student_list.setFixedHeight(300)
         left_layout.addWidget(self.student_list)
 
         splitter.addWidget(left_container)
 
-        right_container = QWidget()
+        right_container = QFrame()
+        right_container.setStyleSheet(card_style(COLOR_PALETTE["secondary"].name()))
         right_layout = QVBoxLayout(right_container)
         right_layout.setSpacing(24)
+        right_layout.setContentsMargins(16, 16, 16, 16)
 
         right_label = QLabel("XP vergeben")
         right_label.setFont(make_font(FONT_SIZES["body"], bold=True))

--- a/ui/students_tab.py
+++ b/ui/students_tab.py
@@ -18,11 +18,12 @@ from PyQt5.QtWidgets import (
     QVBoxLayout,
     QWidget,
     QSizePolicy,
+    QHBoxLayout,
 )
 
 from data.models import Badge, Student
 from data.store import DataStore
-from ui.theme import FONT_SIZES, button_style, make_font
+from ui.theme import COLOR_PALETTE, FONT_SIZES, button_style, card_style, make_font
 from ui.vector_assets import AVATAR_SVG, BADGE_SVGS
 
 
@@ -75,9 +76,10 @@ class BadgeGallery(QWidget):
             self._layout.addWidget(card, row, col)
 
 
-class StudentDetail(QWidget):
+class StudentDetail(QFrame):
     def __init__(self, parent: Optional[QWidget] = None) -> None:
         super().__init__(parent)
+        self.setStyleSheet(card_style(COLOR_PALETTE["mint"].name()))
         splitter = QSplitter(Qt.Horizontal, self)
         splitter.setChildrenCollapsible(False)
         splitter.setHandleWidth(12)
@@ -91,8 +93,15 @@ class StudentDetail(QWidget):
         info_layout.setSpacing(16)
         info_layout.setContentsMargins(24, 24, 24, 24)
 
+        title_row = QHBoxLayout()
+        title_row.setSpacing(12)
         self.name_label = QLabel("Schüler:in")
-        self.name_label.setFont(make_font(28, bold=True))
+        self.name_label.setFont(make_font(30, bold=True))
+        cheer_label = QLabel("🌟")
+        cheer_label.setFont(make_font(30))
+        title_row.addWidget(self.name_label)
+        title_row.addWidget(cheer_label)
+        title_row.addStretch(1)
 
         self.level_label = QLabel("Level 1")
         self.level_label.setFont(make_font(FONT_SIZES["heading"], bold=True))
@@ -103,13 +112,14 @@ class StudentDetail(QWidget):
         self.progress = QProgressBar()
         self.progress.setRange(0, 100)
         self.progress.setTextVisible(True)
-        self.progress.setFormat("Fortschritt zum nächsten Level: %p%")
+        self.progress.setFormat("Abenteuer zum nächsten Level: %p%")
         self.progress.setStyleSheet(
-            "QProgressBar { border-radius: 16px; height: 36px; font-size: 16px; }"
-            "QProgressBar::chunk { background-color: #10B981; border-radius: 16px; }"
+            "QProgressBar { border-radius: 16px; height: 36px; font-size: 16px;"
+            " background: #E2F8CE; padding: 4px; }"
+            "QProgressBar::chunk { background-color: #58CC02; border-radius: 12px; }"
         )
 
-        info_layout.addWidget(self.name_label)
+        info_layout.addLayout(title_row)
         info_layout.addWidget(self.level_label)
         info_layout.addWidget(self.xp_label)
         info_layout.addWidget(self.progress)
@@ -119,7 +129,12 @@ class StudentDetail(QWidget):
         info_layout.addWidget(badge_header)
 
         self.badge_gallery = BadgeGallery()
-        info_layout.addWidget(self.badge_gallery)
+        badge_wrapper = QFrame()
+        badge_wrapper.setStyleSheet(card_style(COLOR_PALETTE["sky"].name()))
+        badge_layout = QVBoxLayout(badge_wrapper)
+        badge_layout.setContentsMargins(12, 12, 12, 12)
+        badge_layout.addWidget(self.badge_gallery)
+        info_layout.addWidget(badge_wrapper)
         info_layout.addStretch(1)
 
         splitter.addWidget(self.info_panel)
@@ -129,6 +144,10 @@ class StudentDetail(QWidget):
 
         layout = QVBoxLayout(self)
         layout.addWidget(splitter)
+
+        helper = QLabel("Tipp: Vergib Belohnungen, um neue Orden aufzuschalten!")
+        helper.setFont(make_font(FONT_SIZES["caption"], bold=True))
+        layout.addWidget(helper, alignment=Qt.AlignRight)
 
     def update_student(self, student: Student) -> None:
         self.name_label.setText(student.display_name)
@@ -157,17 +176,35 @@ class StudentsTab(QWidget):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(16)
+        layout.setSpacing(18)
 
+        hero = QFrame()
+        hero.setStyleSheet(card_style(COLOR_PALETTE["primary"].name()))
+        hero_layout = QHBoxLayout(hero)
+        hero_layout.setSpacing(12)
+        hero_title = QLabel("🌈 Abenteuer-Klasse")
+        hero_title.setFont(make_font(FONT_SIZES["heading"], bold=True))
+        hero_sub = QLabel("Wähle ein Kind aus und begleite es durch Level, Orden und XP!")
+        hero_sub.setFont(make_font(FONT_SIZES["body"]))
+        hero_layout.addWidget(hero_title)
+        hero_layout.addWidget(hero_sub)
+        hero_layout.addStretch(1)
+        layout.addWidget(hero)
+
+        list_frame = QFrame()
+        list_frame.setStyleSheet(card_style(COLOR_PALETTE["sky"].name()))
+        list_layout = QVBoxLayout(list_frame)
+        list_layout.setContentsMargins(12, 12, 12, 12)
         header = QLabel("Schüler:innen")
-        header.setFont(make_font(FONT_SIZES["heading"], bold=True))
-        layout.addWidget(header)
+        header.setFont(make_font(FONT_SIZES["subheading"], bold=True))
+        list_layout.addWidget(header)
 
         self.student_list = QListWidget()
         self.student_list.setSpacing(12)
-        self.student_list.setFixedHeight(140)
+        self.student_list.setFixedHeight(180)
         self.student_list.itemSelectionChanged.connect(self._on_selection_changed)
-        layout.addWidget(self.student_list)
+        list_layout.addWidget(self.student_list)
+        layout.addWidget(list_frame)
 
         self.detail = StudentDetail()
         layout.addWidget(self.detail, stretch=1)

--- a/ui/theme.py
+++ b/ui/theme.py
@@ -3,19 +3,22 @@ from __future__ import annotations
 
 from PyQt5.QtGui import QColor, QFont
 
+# A Duolingo-inspired, kid-friendly palette with vivid greens and sunshine yellows.
 COLOR_PALETTE = {
-    "background": QColor("#F8FAFC"),
+    "background": QColor("#F4FDF3"),
     "surface": QColor("#FFFFFF"),
-    "primary": QColor("#3B82F6"),
-    "secondary": QColor("#F59E0B"),
-    "success": QColor("#10B981"),
-    "warning": QColor("#EF4444"),
-    "text_primary": QColor("#0F172A"),
+    "primary": QColor("#58CC02"),
+    "secondary": QColor("#FFD93B"),
+    "success": QColor("#2DD4BF"),
+    "warning": QColor("#FF6B6B"),
+    "text_primary": QColor("#1E293B"),
     "text_secondary": QColor("#475569"),
+    "mint": QColor("#B7F0B1"),
+    "sky": QColor("#B3E5FC"),
 }
 
 FONT_SIZES = {
-    "heading": 32,
+    "heading": 34,
     "subheading": 24,
     "body": 18,
     "caption": 14,
@@ -31,8 +34,61 @@ def apply_global_palette(app) -> None:
     palette.setColor(palette.WindowText, COLOR_PALETTE["text_primary"])
     palette.setColor(palette.ButtonText, COLOR_PALETTE["surface"])
     palette.setColor(palette.Highlight, COLOR_PALETTE["secondary"])
-    palette.setColor(palette.HighlightedText, COLOR_PALETTE["surface"])
+    palette.setColor(palette.HighlightedText, COLOR_PALETTE["text_primary"])
     app.setPalette(palette)
+    app.setStyleSheet(
+        """
+        QWidget {
+            font-family: "Baloo 2", "Arial Rounded MT", "Arial";
+            color: #1E293B;
+        }
+        QScrollArea {
+            border: none;
+        }
+        QListWidget {
+            background: #FFFFFF;
+            border: 3px solid #C7F9CC;
+            border-radius: 18px;
+            padding: 8px;
+        }
+        QListWidget::item {
+            padding: 12px;
+            border-radius: 12px;
+        }
+        QListWidget::item:selected {
+            background: #E2F8CE;
+            color: #1A2E05;
+        }
+        QListWidget::item:hover {
+            background: #F4FDF3;
+        }
+        QTabBar::tab {
+            background: #FFFFFF;
+            border: 3px solid #C7F9CC;
+            border-bottom: none;
+            border-top-left-radius: 18px;
+            border-top-right-radius: 18px;
+            padding: 12px 24px;
+            margin: 0 6px;
+            font-weight: 700;
+        }
+        QTabBar::tab:selected {
+            background: #E2F8CE;
+            border-color: #58CC02;
+        }
+        QTabWidget::pane {
+            border: 3px solid #C7F9CC;
+            border-radius: 18px;
+            top: -2px;
+        }
+        QMessageBox {
+            background: #FFFFFF;
+        }
+        QMessageBox QLabel {
+            font-size: 18px;
+        }
+        """
+    )
 
 
 def make_font(point_size: int, bold: bool = False) -> QFont:
@@ -43,23 +99,40 @@ def make_font(point_size: int, bold: bool = False) -> QFont:
 
 def button_style(role: str = "primary") -> str:
     color = COLOR_PALETTE.get(role, COLOR_PALETTE["primary"]).name()
-    text_color = "#FFFFFF"
+    text_color = "#0F172A"
     return f"""
         QPushButton {{
             background-color: {color};
             color: {text_color};
-            border-radius: 16px;
-            padding: 16px 24px;
-            min-height: 64px;
+            border: 3px solid {lighten(color, 0.9)};
+            border-radius: 20px;
+            padding: 16px 28px;
+            min-height: 72px;
             font-size: 20px;
-            font-weight: 600;
+            font-weight: 800;
+            letter-spacing: 0.5px;
         }}
         QPushButton:pressed {{
-            background-color: {lighten(color, 1.1)};
+            background-color: {lighten(color, 0.9)};
         }}
         QPushButton:disabled {{
-            background-color: #CBD5F5;
-            color: #64748B;
+            background-color: #DAE5D5;
+            color: #94A3B8;
+        }}
+    """
+
+
+def card_style(accent: str = "#58CC02", gradient: bool = True) -> str:
+    background = (
+        f"background: qlineargradient(x1:0 y1:0, x2:1 y2:1,"
+        f" stop:0 {lighten(accent, 1.45)}, stop:1 {lighten(accent, 1.15)});"
+    ) if gradient else "background: #FFFFFF;"
+    return f"""
+        QFrame {{
+            {background}
+            border: 4px solid {lighten(accent, 0.9)};
+            border-radius: 24px;
+            padding: 20px;
         }}
     """
 

--- a/ui/trophy_cabinet.py
+++ b/ui/trophy_cabinet.py
@@ -18,7 +18,7 @@ from PyQt5.QtWidgets import (
 
 from data.models import Badge
 from data.store import DataStore
-from ui.theme import FONT_SIZES, make_font
+from ui.theme import COLOR_PALETTE, FONT_SIZES, card_style, make_font
 
 
 class BadgeDetailDialog(QDialog):
@@ -61,10 +61,7 @@ class TrophyCard(QFrame):
         super().__init__(parent)
         self.badge = badge
         self.setFrameShape(QFrame.StyledPanel)
-        self.setStyleSheet(
-            "QFrame { background: #FFFFFF; border-radius: 24px; border: 4px solid #DBEAFE; }"
-            "QFrame:hover { border-color: #3B82F6; }"
-        )
+        self.setStyleSheet(card_style(COLOR_PALETTE["secondary"].name()))
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
         layout.setSpacing(12)
@@ -99,11 +96,19 @@ class TrophyCabinetTab(QWidget):
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(24, 24, 24, 24)
-        layout.setSpacing(16)
+        layout.setSpacing(18)
 
-        header = QLabel("Trophäenschrank")
-        header.setFont(make_font(FONT_SIZES["heading"], bold=True))
-        layout.addWidget(header)
+        hero = QFrame()
+        hero.setStyleSheet(card_style(COLOR_PALETTE["primary"].name()))
+        hero_layout = QVBoxLayout(hero)
+        hero_layout.setSpacing(6)
+        hero_title = QLabel("🏆 Glitzernder Trophäenschrank")
+        hero_title.setFont(make_font(FONT_SIZES["heading"], bold=True))
+        hero_sub = QLabel("Tippe auf einen Orden, um mehr zu erfahren – sammel sie alle!")
+        hero_sub.setFont(make_font(FONT_SIZES["body"]))
+        hero_layout.addWidget(hero_title)
+        hero_layout.addWidget(hero_sub)
+        layout.addWidget(hero)
 
         self.scroll_area = QScrollArea()
         self.scroll_area.setWidgetResizable(True)


### PR DESCRIPTION
## Summary
- refresh the PyQt UI with a Duolingo-inspired green palette, playful typography, and rounded tab styling
- restyle students, rewards, and trophy views with hero banners, colorful cards, and upbeat helper text
- adjust progress, lists, and badge displays for a friendlier, kid-focused dashboard experience

## Testing
- not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bd407f18c832caa0ca649e13e416a)